### PR TITLE
fix: SolcJS compiler version label

### DIFF
--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -16,7 +16,7 @@ import SCEditor from 'react-simple-code-editor'
 import { EthereumContext } from 'context/ethereumContext'
 import { SettingsContext, Setting } from 'context/settingsContext'
 
-import { getTargetEvmVersion } from 'util/compiler'
+import { getTargetEvmVersion, compilerSemVer } from 'util/compiler'
 import { codeHighlight, isEmpty, isHex } from 'util/string'
 
 import examples from 'components/Editor/examples'
@@ -39,9 +39,6 @@ type SCEditorRef = {
 const editorHeight = 350
 const consoleHeight = 350
 
-// FIXME: Handle compiler detection
-const compilerVersion = 'v0.8.9'
-
 const Editor = ({ readOnly = false }: Props) => {
   const { settingsLoaded, getSetting, setSetting } = useContext(SettingsContext)
 
@@ -61,7 +58,7 @@ const Editor = ({ readOnly = false }: Props) => {
   const [output, setOutput] = useState<IConsoleOutput[]>([
     {
       type: 'info',
-      message: `Loading Solidity compiler ${compilerVersion}...`,
+      message: `Loading Solidity compiler ${compilerSemVer}...`,
     },
   ])
   const solcWorkerRef = useRef<null | Worker>(null)
@@ -262,7 +259,7 @@ const Editor = ({ readOnly = false }: Props) => {
       </div>
 
       <div className="rounded-b-lg py-2 px-4 border-t bg-gray-800 dark:bg-black-700 border-black-900 border-opacity-25 text-gray-400 dark:text-gray-600 text-xs">
-        Solidity Compiler {compilerVersion}
+        Solidity Compiler {compilerSemVer}
       </div>
     </div>
   )

--- a/lib/solcWorker.js
+++ b/lib/solcWorker.js
@@ -1,8 +1,8 @@
-importScripts(
-  'https://solc-bin.ethereum.org/bin/soljson-v0.8.10+commit.fc410830.js',
-)
+import { compilerVersion } from 'util/compiler'
 
-// Code extracted from https://github.com/ethereum/solc-js/blob/v0.8.9/wrapper.js
+importScripts(`https://solc-bin.ethereum.org/bin/${compilerVersion}.js`)
+
+// Code extracted from https://github.com/ethereum/solc-js/blob/{compilerVersion}/wrapper.js
 const alloc = cwrap('solidity_alloc', 'number', ['number'])
 const copyFromCString = UTF8ToString
 const reset = cwrap('solidity_reset', null, [])

--- a/util/compiler.ts
+++ b/util/compiler.ts
@@ -1,3 +1,6 @@
+export const compilerSemVer = 'v0.8.10'
+export const compilerVersion = `soljson-${compilerSemVer}+commit.fc410830`
+
 /**
  * Gets target EVM version from a hardfork name
  *


### PR DESCRIPTION
This extracts compiler version to util/compiler so we don't forget to update it everywhere next time.