### PR TITLE
SSTORE gas variable definitions

### DIFF
--- a/docs/opcodes/55/berlin.mdx
+++ b/docs/opcodes/55/berlin.mdx
@@ -5,6 +5,7 @@
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
+
     static_gas = {gasPrices|sstore}
 
     if value == current_value

--- a/docs/opcodes/55/berlin.mdx
+++ b/docs/opcodes/55/berlin.mdx
@@ -1,10 +1,11 @@
 ## Gas
 
 ### Definitions:
-- **value**: The value of the storage slot after executing the opcode SSTORE.
-- **current_value**: The value of the storage slot before executing the opcode SSTORE.
-- **original_value**: The value of the storage slot at the beginning of the transaction.
-##
+- **value**: Value from the stack input.
+- **current_value**: Current value of the storage slot.
+- **original_value**: Value of the storage slot before the current transaction.
+
+```
     static_gas = {gasPrices|sstore}
 
     if value == current_value
@@ -16,6 +17,7 @@
             base_dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
     else
         base_dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
+```
 
 On top of the cost above, {gasPrices|warmstorageread} is added if the slot is warm, or {gasPrices|coldsload} otherwise. See section [access sets](/about).
 

--- a/docs/opcodes/55/berlin.mdx
+++ b/docs/opcodes/55/berlin.mdx
@@ -3,7 +3,7 @@
 ### Definitions:
 - **value**: The value of the storage slot after executing the opcode SSTORE.
 - **current_value**: The value of the storage slot before executing the opcode SSTORE.
-- **original_value**: The value of the storage slot before at the beginning of the transaction.
+- **original_value**: The value of the storage slot at the beginning of the transaction.
 ##
     static_gas = {gasPrices|sstore}
 

--- a/docs/opcodes/55/berlin.mdx
+++ b/docs/opcodes/55/berlin.mdx
@@ -1,11 +1,10 @@
 ## Gas
 
 ### Definitions:
-- **value**: Value from the stack input.
-- **current_value**: Current value of the storage slot.
-- **original_value**: Value of the storage slot before the current transaction.
+- **value**: value from the stack input.
+- **current_value**: current value of the storage slot.
+- **original_value**: value of the storage slot before the current transaction.
 
-```
     static_gas = {gasPrices|sstore}
 
     if value == current_value
@@ -17,7 +16,6 @@
             base_dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
     else
         base_dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
-```
 
 On top of the cost above, {gasPrices|warmstorageread} is added if the slot is warm, or {gasPrices|coldsload} otherwise. See section [access sets](/about).
 

--- a/docs/opcodes/55/berlin.mdx
+++ b/docs/opcodes/55/berlin.mdx
@@ -1,5 +1,10 @@
 ## Gas
 
+### Definitions:
+- **value**: The value of the storage slot after executing the opcode SSTORE.
+- **current_value**: The value of the storage slot before executing the opcode SSTORE.
+- **original_value**: The value of the storage slot before at the beginning of the transaction.
+##
     static_gas = {gasPrices|sstore}
 
     if value == current_value

--- a/docs/opcodes/55/constantinople.mdx
+++ b/docs/opcodes/55/constantinople.mdx
@@ -5,6 +5,7 @@
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
+
     static_gas = {gasPrices|sstore}
 
     if value == current_value

--- a/docs/opcodes/55/constantinople.mdx
+++ b/docs/opcodes/55/constantinople.mdx
@@ -1,11 +1,10 @@
 ## Gas
 
 ### Definitions:
-- **value**: Value from the stack input.
-- **current_value**: Current value of the storage slot.
-- **original_value**: Value of the storage slot before the current transaction.
+- **value**: value from the stack input.
+- **current_value**: current value of the storage slot.
+- **original_value**: value of the storage slot before the current transaction.
 
-```
     static_gas = {gasPrices|sstore}
 
     if value == current_value
@@ -17,7 +16,6 @@
             dynamic_gas = {gasPrices|netSstoreCleanGas}
     else
         dynamic_gas = {gasPrices|netSstoreDirtyGas}
-```
 
 ## Gas refunds
 

--- a/docs/opcodes/55/constantinople.mdx
+++ b/docs/opcodes/55/constantinople.mdx
@@ -1,10 +1,11 @@
 ## Gas
 
 ### Definitions:
-- **value**: The value of the storage slot after executing the opcode SSTORE.
-- **current_value**: The value of the storage slot before executing the opcode SSTORE.
-- **original_value**: The value of the storage slot at the beginning of the transaction.
-##
+- **value**: Value from the stack input.
+- **current_value**: Current value of the storage slot.
+- **original_value**: Value of the storage slot before the current transaction.
+
+```
     static_gas = {gasPrices|sstore}
 
     if value == current_value
@@ -16,6 +17,7 @@
             dynamic_gas = {gasPrices|netSstoreCleanGas}
     else
         dynamic_gas = {gasPrices|netSstoreDirtyGas}
+```
 
 ## Gas refunds
 

--- a/docs/opcodes/55/constantinople.mdx
+++ b/docs/opcodes/55/constantinople.mdx
@@ -3,7 +3,7 @@
 ### Definitions:
 - **value**: The value of the storage slot after executing the opcode SSTORE.
 - **current_value**: The value of the storage slot before executing the opcode SSTORE.
-- **original_value**: The value of the storage slot before at the beginning of the transaction.
+- **original_value**: The value of the storage slot at the beginning of the transaction.
 ##
     static_gas = {gasPrices|sstore}
 

--- a/docs/opcodes/55/constantinople.mdx
+++ b/docs/opcodes/55/constantinople.mdx
@@ -1,5 +1,10 @@
 ## Gas
 
+### Definitions:
+- **value**: The value of the storage slot after executing the opcode SSTORE.
+- **current_value**: The value of the storage slot before executing the opcode SSTORE.
+- **original_value**: The value of the storage slot before at the beginning of the transaction.
+##
     static_gas = {gasPrices|sstore}
 
     if value == current_value

--- a/docs/opcodes/55/istanbul.mdx
+++ b/docs/opcodes/55/istanbul.mdx
@@ -5,6 +5,7 @@
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
+
     static_gas = {gasPrices|sstore}
 
     if value == current_value

--- a/docs/opcodes/55/istanbul.mdx
+++ b/docs/opcodes/55/istanbul.mdx
@@ -3,7 +3,7 @@
 ### Definitions:
 - **value**: The value of the storage slot after executing the opcode SSTORE.
 - **current_value**: The value of the storage slot before executing the opcode SSTORE.
-- **original_value**: The value of the storage slot before at the beginning of the transaction.
+- **original_value**: The value of the storage slot at the beginning of the transaction.
 ##
     static_gas = {gasPrices|sstore}
 

--- a/docs/opcodes/55/istanbul.mdx
+++ b/docs/opcodes/55/istanbul.mdx
@@ -1,11 +1,10 @@
 ## Gas
 
 ### Definitions:
-- **value**: Value from the stack input.
-- **current_value**: Current value of the storage slot.
-- **original_value**: Value of the storage slot before the current transaction.
+- **value**: value from the stack input.
+- **current_value**: current value of the storage slot.
+- **original_value**: value of the storage slot before the current transaction.
 
-```
     static_gas = {gasPrices|sstore}
 
     if value == current_value
@@ -17,7 +16,6 @@
             dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
     else
         dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
-```
 
 ## Gas refunds
 

--- a/docs/opcodes/55/istanbul.mdx
+++ b/docs/opcodes/55/istanbul.mdx
@@ -1,10 +1,11 @@
 ## Gas
 
 ### Definitions:
-- **value**: The value of the storage slot after executing the opcode SSTORE.
-- **current_value**: The value of the storage slot before executing the opcode SSTORE.
-- **original_value**: The value of the storage slot at the beginning of the transaction.
-##
+- **value**: Value from the stack input.
+- **current_value**: Current value of the storage slot.
+- **original_value**: Value of the storage slot before the current transaction.
+
+```
     static_gas = {gasPrices|sstore}
 
     if value == current_value
@@ -16,6 +17,7 @@
             dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
     else
         dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
+```
 
 ## Gas refunds
 

--- a/docs/opcodes/55/istanbul.mdx
+++ b/docs/opcodes/55/istanbul.mdx
@@ -1,5 +1,10 @@
 ## Gas
 
+### Definitions:
+- **value**: The value of the storage slot after executing the opcode SSTORE.
+- **current_value**: The value of the storage slot before executing the opcode SSTORE.
+- **original_value**: The value of the storage slot before at the beginning of the transaction.
+##
     static_gas = {gasPrices|sstore}
 
     if value == current_value

--- a/opcodes.json
+++ b/opcodes.json
@@ -655,7 +655,7 @@
           },
           "originalValue": {
             "type": "number",
-            "label": "State: original value at the beginning of the transaction"
+            "label": "State: original value before the current transaction"
           }
         }
       },
@@ -683,7 +683,7 @@
           },
           "originalValue": {
             "type": "number",
-            "label": "State: original value at the beginning of the transaction"
+            "label": "State: original value before the current transaction"
           }
         }
       },
@@ -699,7 +699,7 @@
           },
           "originalValue": {
             "type": "number",
-            "label": "State: original value at the beginning of the transaction"
+            "label": "State: original value before the current transaction"
           },
           "cold": {
             "type": "boolean",


### PR DESCRIPTION
Adding the definitions of `value`, `current_value` and `original_value` for opcode SSTORE gas computation variables