### PR TITLE
fix: getAbsoluteURL and remove unnecessary dot files

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,0 @@
-# .env.development
-NEXT_PUBLIC_VERCEL_URL=http://localhost:3000

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,0 @@
-# .env.production
-NEXT_PUBLIC_VERCEL_URL=https://${VERCEL_URL}

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -20,6 +20,7 @@ import SCEditor from 'react-simple-code-editor'
 import { EthereumContext } from 'context/ethereumContext'
 import { SettingsContext, Setting } from 'context/settingsContext'
 
+import { getAbsoluteURL } from 'util/browser'
 import {
   getTargetEvmVersion,
   compilerSemVer,
@@ -318,11 +319,7 @@ const Editor = ({ readOnly = false }: Props) => {
       code: encodeURIComponent(encode(JSON.stringify(code))),
     }
 
-    copy(
-      `${process.env.NEXT_PUBLIC_VERCEL_URL}/playground?${objToQueryString(
-        params,
-      )}`,
-    )
+    copy(`${getAbsoluteURL('/playground')}?${objToQueryString(params)}`)
     log('Link to current code, calldata and value copied to clipboard')
   }, [callValue, unit, callData, codeType, code, log])
 

--- a/util/browser.ts
+++ b/util/browser.ts
@@ -4,8 +4,8 @@ export const isMac =
     : false
 
 export const getAbsoluteURL = (path = '') => {
-  const baseURL = process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
+  const baseURL = process.env.NEXT_PUBLIC_VERCEL_URL
+    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
     : 'http://localhost:3000'
   return baseURL + path
 }


### PR DESCRIPTION
The dotfiles introduced in #103 and #104 are not needed since `NEXT_PUBLIC_VERCEL_URL` is already one of the [exposed environment variable](https://vercel.com/docs/concepts/projects/environment-variables) by Vercel. The original bug was not using the correct prefix in the `getAbsoluteURL` of `util/browser.ts`, which is fixed in this PR. After deploying this one, the custom environment variable in the Vercel settings is no longer required too - check out the Preview environment where it works w/o it.