### PR TITLE
fix: add stack output to CREATE documentation

### DIFF
--- a/docs/opcodes/F0.mdx
+++ b/docs/opcodes/F0.mdx
@@ -11,6 +11,10 @@ group: System operations
 1. `offset`: byte offset in the [memory](/about) in bytes, the instructions of the new account.
 2. `size`: byte size to copy (size of the instructions).
 
+## Stack output
+
+0. `address`: the address of the deployed contract.
+
 ## Examples
 
 [See in playground](/playground?callValue=9&unit=Wei&codeType=Mnemonic&code='z0q0f9q9f0y4%20FFmslk3%200x63FFFFFFFF60005260046000F3jvMSTORE~13jjp%20'~k%20z%2F%2F%20Createmnmccountgith%20ygeimnd%20v%5Cnqynoljj~pvCREATEm%20al%20codekvPUSH1j~0g%20wfpvvz%01fgjklmpqvyz~_).


### PR DESCRIPTION
I'm assuming the stack output of CREATE was accidentally omitted, rather than intentionally (given it is included in CREATE2 and most opcodes document their stack output). Address is correctly mentioned in the "STACK OUTPUT" portion of the opcode table, so this is just a minor issue with aligning the docs