### PR TITLE
Disable 'cold' option when estimating SSTORE gas costs with known warm storage

### DIFF
--- a/components/Reference/DynamicFee.tsx
+++ b/components/Reference/DynamicFee.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useContext } from 'react'
+import Common from '@ethereumjs/common'
 
 import debounce from 'lodash.debounce'
 import { IReferenceItem } from 'types'
@@ -27,6 +28,7 @@ const DynamicFee = ({ referenceItem, fork }: Props) => {
 
   const { common } = useContext(EthereumContext)
   const [inputs, setInputs] = useState<InputValue | undefined>()
+  const [disabled, setDisabled] = useState<Set<string>>(new Set())
   const [gasCost, setGasCost] = useState('0')
   const [gasRefund, setGasRefund] = useState('0')
   const [canRefund, setCanRefund] = useState(false)
@@ -34,9 +36,15 @@ const DynamicFee = ({ referenceItem, fork }: Props) => {
   const handleCompute = debounce((inputs) => {
     if (common) {
       try {
-        setGasCost(calculateDynamicFee(referenceItem, common, inputs))
+        setDisabled(calculateDisabledInputs(referenceItem, common, inputs))
+        const updatedInputs = { ...inputs }
+        for (let key in disabled.values()) {
+          updatedInputs[key] = '0'
+        }
 
-        const refund = calculateDynamicRefund(referenceItem, common, inputs)
+        setGasCost(calculateDynamicFee(referenceItem, common, updatedInputs))
+
+        const refund = calculateDynamicRefund(referenceItem, common, updatedInputs)
         if (refund != null) {
           setCanRefund(true)
           setGasRefund(refund)
@@ -48,6 +56,20 @@ const DynamicFee = ({ referenceItem, fork }: Props) => {
       }
     }
   }, debounceTimeout)
+
+  const calculateDisabledInputs = (
+    opcode: IReferenceItem,
+    common: Common,
+    inputs: any,
+  ) => {
+    if (opcode.opcodeOrAddress === '55' && common.gteHardfork('berlin')) {
+      if (inputs.currentValue !== inputs.originalValue) {
+        return new Set(['cold'])
+      }
+    }
+
+    return new Set([])
+  }
 
   // Initialize inputs with default keys & values
   useEffect(() => {
@@ -106,13 +128,15 @@ const DynamicFee = ({ referenceItem, fork }: Props) => {
                   <Radio
                     text="Yes"
                     value={'1'}
-                    isChecked={inputs[key] === '1'}
+                    isChecked={inputs[key] === '1' && !disabled.has(key)}
+                    isDisabled={disabled.has(key)}
                     onChange={() => handleChange(key, '1')}
                   />
                   <Radio
                     text="No"
                     value={'0'}
-                    isChecked={inputs[key] === '0'}
+                    isChecked={inputs[key] === '0' || disabled.has(key)}
+                    isDisabled={disabled.has(key)}
                     onChange={() => handleChange(key, '0')}
                   />
                 </div>

--- a/components/Reference/DynamicFee.tsx
+++ b/components/Reference/DynamicFee.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useContext } from 'react'
-import Common from '@ethereumjs/common'
 
+import Common from '@ethereumjs/common'
 import debounce from 'lodash.debounce'
 import { IReferenceItem } from 'types'
 
@@ -38,13 +38,17 @@ const DynamicFee = ({ referenceItem, fork }: Props) => {
       try {
         setDisabled(calculateDisabledInputs(referenceItem, common, inputs))
         const updatedInputs = { ...inputs }
-        for (let key in disabled.values()) {
+        for (const key in disabled.values()) {
           updatedInputs[key] = '0'
         }
 
         setGasCost(calculateDynamicFee(referenceItem, common, updatedInputs))
 
-        const refund = calculateDynamicRefund(referenceItem, common, updatedInputs)
+        const refund = calculateDynamicRefund(
+          referenceItem,
+          common,
+          updatedInputs,
+        )
         if (refund != null) {
           setCanRefund(true)
           setGasRefund(refund)

--- a/components/ui/Radio.tsx
+++ b/components/ui/Radio.tsx
@@ -5,6 +5,7 @@ type Props = {
   value: string
   onChange: (event: ChangeEvent<HTMLInputElement>) => void
   isChecked: boolean
+  isDisabled?: boolean
 }
 
 export const Radio: React.FC<Props> = ({
@@ -12,6 +13,7 @@ export const Radio: React.FC<Props> = ({
   value,
   onChange,
   isChecked,
+  isDisabled,
 }) => {
   return (
     <label className="mr-3 text-sm">
@@ -19,6 +21,7 @@ export const Radio: React.FC<Props> = ({
         type="radio"
         value={value}
         checked={isChecked}
+        disabled={isDisabled || false}
         onChange={onChange}
         className="mr-2"
       />


### PR DESCRIPTION
When estimating the gas cost of the SSTORE instruction, we provide an option to tell the calculator if the storage is warm or cold. However, if the current value of the slot is different from the original value, that implies that the slot has already been touched as part of this transaction and therefore can't be cold.

This change disables the 'cold' option when current value != original value and visually causes the option to appear as though the user has selected 'No' (meaning 'not cold'), when disabled. If current value and original value are later changed to be equal again, the 'cold' option is restored to whatever value was selected before.

Resolves #118 