### PR TITLE
changed a typo got Log4 opcode.

### DIFF
--- a/docs/opcodes/A4.mdx
+++ b/docs/opcodes/A4.mdx
@@ -11,7 +11,7 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 
 ## Stack input
 
-0. `topic`: byte topic in the [memory](/about) in bytes.
+0. `offset`: byte offset in the [memory](/about) in bytes.
 1. `size`: byte size to copy.
 2. `topic1`: 32-byte value.
 3. `topic2`: 32-byte value.


### PR DESCRIPTION
The first stack item was `topic` which should have been `offset`. This pull request fixes this typo.