### PR TITLE
prepend 0x to opcodes codes

### DIFF
--- a/components/Reference/columns.tsx
+++ b/components/Reference/columns.tsx
@@ -11,7 +11,7 @@ const columns = (isPrecompiled: boolean) => [
   {
     Header: !isPrecompiled ? 'Opcode' : 'Address',
     accessor: 'opcodeOrAddress',
-    className: !isPrecompiled ? 'uppercase' : undefined,
+    className: undefined,
     filter,
     width: 48,
   },

--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -423,7 +423,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
       const opcode = {
         ...meta[toHex(op.code)],
         ...{
-          opcodeOrAddress: toHex(op.code),
+          opcodeOrAddress: '0x' + toHex(op.code).toUpperCase(),
           staticFee: op.fee,
           minimumFee: 0,
           name: op.fullName,


### PR DESCRIPTION
The opcode numbers are in hex, but the UI doesn't display them as such. This fixes that.

Before:
<img width="97" alt="Screen Shot 2022-05-17 at 4 17 14 PM" src="https://user-images.githubusercontent.com/1106201/168902682-1d20cc45-4bce-416c-985f-e70e10a8dcbd.png">


After:

<img width="124" alt="Screen Shot 2022-05-17 at 4 17 05 PM" src="https://user-images.githubusercontent.com/1106201/168902732-0e54e358-04bd-47e4-bfb1-6c13fb140f98.png">

