### PR TITLE
Fix: CREATE and CREATE2 return values on failure (#142)

### DIFF
--- a/docs/opcodes/F0.mdx
+++ b/docs/opcodes/F0.mdx
@@ -5,15 +5,33 @@ group: System operations
 
 *Index 1 is top of the stack. See [PUSH](/#60).*
 
+## Notes
+
+Creates a new contract. Enters a new sub [context](/about) of the calculated destination address and executes the provided initialisation code, then resumes the current context.
+
+Should deployment succeed, the new account's [code](/about) is set to the [return data](/about) resulting from executing the initialisation code.
+
+The destination address is calculated as the rightmost 20 bytes (160 bits) of the Keccak-256 hash of the rlp encoding of the sender address followed by its nonce. That is:
+
+    address = keccak256(rlp([sender_address,sender_nonce]))[12:]
+
+Deployment can fail due to:
+- Insufficient value to send.
+- Sub [context](/about) [reverted](/#FD).
+- Insufficient gas to execute the initialisation code.
+- Call depth limit reached.
+
+Note that these failures only affect the return value and do not cause the calling context to revert (unlike the error cases below).
+
 ## Stack input
 
 0. `value`: value in [wei](https://www.investopedia.com/terms/w/wei.asp) to send to the new account.
-1. `offset`: byte offset in the [memory](/about) in bytes, the instructions of the new account.
-2. `size`: byte size to copy (size of the instructions).
+1. `offset`: byte offset in the [memory](/about) in bytes, the initialisation code for the new account.
+2. `size`: byte size to copy (size of the initialisation code).
 
 ## Stack output
 
-0. `address`: the address of the deployed contract.
+0. `address`: the address of the deployed contract, 0 if the deployment failed.
 
 ## Examples
 

--- a/docs/opcodes/F5.mdx
+++ b/docs/opcodes/F5.mdx
@@ -7,18 +7,34 @@ group: System operations
 
 ## Notes
 
-Equivalent to [CREATE](/#F0), except the salt allows the new contract to be deployed at a deterministic address.
+Equivalent to [CREATE](/#F0), except the salt allows the new contract to be deployed at a consistent, deterministic address.
+
+Should deployment succeed, the account's [code](/about) is set to the [return data](/about) resulting from executing the initialisation code.
+
+The destination address is calculated as follows:
+
+    initialisation_code = memory[offset:offset+size]
+    address = keccak256(0xff + sender_address + salt + keccak256(initialisation_code))[12:]
+
+Deployment can fail due to:
+- A contract already exists at the destination address.
+- Insufficient value to transfer.
+- Sub [context](/about) [reverted](/#FD).
+- Insufficient gas to execute the initialisation code.
+- Call depth limit reached.
+
+Note that these failures only affect the return value and do not cause the calling context to revert (unlike the error cases below).
 
 ## Stack input
 
 0. `value`: value in [wei](https://www.investopedia.com/terms/w/wei.asp) to send to the new account.
-1. `offset`: byte offset in the [memory](/about) in bytes, the instructions of the new account.
-2. `size`: byte size to copy (size of the instructions).
+1. `offset`: byte offset in the [memory](/about) in bytes, the initialisation code of the new account.
+2. `size`: byte size to copy (size of the initialisation code).
 3. `salt`: 32-byte value used to create the new account at a deterministic address.
 
 ## Stack output
 
-0. `address`: the address of the deployed contract.
+0. `address`: the address of the deployed contract, 0 if the deployment failed.
 
 ## Examples
 

--- a/docs/opcodes/F5/berlin.mdx
+++ b/docs/opcodes/F5/berlin.mdx
@@ -8,7 +8,7 @@
 
 The `deployment_code_execution_cost` is the cost of whatever opcode is run to deploy the new contract.
 On top of that, there is an additional cost for storing the code of the new contract, shown as `code_deposit_cost`.
-The difference with [CREATE](#F0) is an additional cost to hash the code before.
+The difference with [CREATE](#F0) is an additional cost to hash the initialisation code before.
 The memory expansion cost explanation can be found [here](/about).
 
 The new contract address is added in the warm addresses. See section [access sets](/about).

--- a/opcodes.json
+++ b/opcodes.json
@@ -1887,7 +1887,7 @@
   "f5": {
     "input": "value | offset | size | salt",
     "output": "address",
-    "description": "Create a new account with associated code",
+    "description": "Create a new account with associated code at a predictable address",
     "dynamicFee": {
       "homestead": {
         "inputs": {


### PR DESCRIPTION
That 0 is returned on failure.

Also more notes describing reasons for failure and how the addresses are
calculated.