### PR TITLE
Minor design/dark-mode improvements

### DIFF
--- a/components/Editor/ExecutionState.tsx
+++ b/components/Editor/ExecutionState.tsx
@@ -23,7 +23,7 @@ const ExecutionStateRow = ({ label, value }: RowProps) => {
 
   return (
     <>
-      <dt className="mb-1 text-gray-500 dark:text-gray-700 font-medium uppercase">
+      <dt className="mb-1 text-gray-500 dark:text-gray-400 font-medium uppercase">
         {label}
       </dt>
       <dd className="font-mono mb-2">
@@ -34,7 +34,7 @@ const ExecutionStateRow = ({ label, value }: RowProps) => {
             showEmpty
             value={value ? value.toString() : ''}
             className={cn(
-              'break-all text-tiny border-gray-600 dark:border-gray-700 text-gray-300 dark:text-gray-400',
+              'break-all text-tiny border-gray-600 dark:border-gray-700 text-gray-300',
             )}
           />
         ))}
@@ -53,7 +53,7 @@ const ExecutionState = () => {
         <ExecutionStateRow label="Memory" value={memory} />
         <ExecutionStateRow label="Stack" value={stack} />
 
-        <dt className="mb-1 text-gray-500 dark:text-gray-700 font-medium uppercase">
+        <dt className="mb-1 text-gray-500 dark:text-gray-400 font-medium uppercase">
           Storage
         </dt>
         <dd className="mb-2">

--- a/components/Editor/Header.tsx
+++ b/components/Editor/Header.tsx
@@ -31,8 +31,8 @@ const EditorHeader = ({ codeType, onCodeTypeChange }: Props) => {
 
   return (
     <div className="flex justify-between items-center w-full">
-      <h3 className="font-semibold text-md hidden xl:block">
-        EVM Playground
+      <h3 className="font-semibold text-md hidden xl:inline-flex items-center">
+        <span>EVM Playground</span>
         <Label>{selectedFork?.name}</Label>
       </h3>
 

--- a/components/Editor/InstructionRow.tsx
+++ b/components/Editor/InstructionRow.tsx
@@ -44,7 +44,7 @@ const EditorInstructionRow = forwardRef(
           'relative border-b border-gray-200 dark:border-black-500',
           {
             'text-gray-900 dark:text-gray-200': isActive,
-            'text-gray-400 dark:text-gray-700': !isActive,
+            'text-gray-400 dark:text-gray-600': !isActive,
           },
         )}
         ref={ref}

--- a/components/Reference/DocRow.tsx
+++ b/components/Reference/DocRow.tsx
@@ -86,7 +86,7 @@ const DocRow = ({
         <>
           <table className="table-auto mb-6 bg-indigo-100 dark:bg-black-500 rounded font-medium">
             <thead>
-              <tr className="text-gray-500 uppercase text-xs">
+              <tr className="text-gray-500 uppercase text-xs tracking-wide">
                 <td className="pt-3 px-4">Since</td>
                 {itemDoc.meta.group && <td className="pt-3 px-4">Group</td>}
               </tr>

--- a/components/Reference/Filters.tsx
+++ b/components/Reference/Filters.tsx
@@ -45,7 +45,7 @@ const Filters = ({ onSetFilter, isPrecompiled = false }: Props) => {
 
   return (
     <div className="flex items-center md:justify-end">
-      <span className="hidden md:inline-block text-sm text-gray-400 dark:text-black-400 mr-3">
+      <span className="hidden md:inline-block text-sm text-gray-400 mr-3">
         Search by
       </span>
 

--- a/components/Reference/Header.tsx
+++ b/components/Reference/Header.tsx
@@ -12,8 +12,8 @@ const ReferenceHeader = ({ isPrecompiled }: Props) => {
   const { selectedFork } = useContext(EthereumContext)
 
   return (
-    <H2 className="pb-8 md:pb-0">
-      {!isPrecompiled ? 'Instructions' : 'Precompiled Contracts'}
+    <H2 className="pb-8 md:pb-0 inline-flex items-center">
+      <span>{!isPrecompiled ? 'Instructions' : 'Precompiled Contracts'}</span>
       {selectedFork && <Label>{selectedFork.name}</Label>}
     </H2>
   )

--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -129,7 +129,7 @@ const ReferenceTable = ({
           {headerGroups.map((headerGroup) => (
             <tr
               key={headerGroup.getHeaderGroupProps().key}
-              className="sticky bg-gray-50 dark:bg-black-700 border-b border-gray-200 dark:border-black-500 uppercase text-xs text-left text-gray-500"
+              className="sticky bg-gray-50 dark:bg-black-700 border-b border-gray-200 dark:border-black-500 uppercase text-xs tracking-wide text-left text-gray-500 dark:text-gray-400"
               style={{
                 top: 54,
               }}

--- a/components/ui/Doc.tsx
+++ b/components/ui/Doc.tsx
@@ -82,7 +82,7 @@ export const A: React.FC<LinkProps> = ({ children, href }) => (
 
 export const Pre: React.FC<Props> = ({ children }) => (
   <div>
-    <pre className="text-tiny inline-block whitespace-pre-wrap p-5 mb-4 bg-indigo-100 dark:bg-black-500 rounded">
+    <pre className="text-tiny inline-block whitespace-pre-wrap p-5 mb-4 bg-indigo-100 dark:bg-gray-800 rounded">
       {children}
     </pre>
   </div>

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -45,13 +45,18 @@ export const Input: React.FC<Props> = ({
       <input
         onFocus={handleFocus}
         onBlur={handleBlur}
-        className="w-full outline-none bg-transparent dark:placeholder-black-400 text-sm"
+        className="w-full outline-none bg-transparent text-sm"
         {...rest}
       />
       {searchable && (
         <Icon
           name="search-line"
-          className="ml-2 text-gray-300 dark:text-black-400"
+          className={cn(
+            'ml-2',
+            isFocused
+              ? 'text-gray-400 dark:text-gray-300'
+              : 'text-gray-300 dark:text-gray-400',
+          )}
         />
       )}
     </div>

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -45,7 +45,7 @@ export const Input: React.FC<Props> = ({
       <input
         onFocus={handleFocus}
         onBlur={handleBlur}
-        className="w-full outline-none bg-transparent text-sm"
+        className="w-full outline-none bg-transparent dark:placeholder-black-400 text-sm"
         {...rest}
       />
       {searchable && (

--- a/components/ui/Label.tsx
+++ b/components/ui/Label.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export const Label: React.FC<Props> = ({ children }) => {
   return children ? (
-    <span className="ml-2 py-1 px-3 bg-gray-200 dark:bg-black-500 uppercase rounded-full text-2xs text-indigo-500 font-medium">
+    <span className="ml-2 py-1 px-3 leading-normal bg-gray-200 dark:bg-black-500 uppercase rounded-full text-2xs tracking-widest text-indigo-500 font-medium">
       {children}
     </span>
   ) : null

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -8,7 +8,7 @@ import { Pre } from 'components/ui/Doc'
 // since frontier, but we have to keep an eye on new fork to keep this up to date
 const AboutPage = () => {
   return (
-    <Container className="text-sm leading-6">
+    <Container className="text-sm leading-6 max-w-4xl">
       <H1>About the EVM</H1>
 
       <H2 className="mb-4">Introduction</H2>


### PR DESCRIPTION
_Note: a lot of these proposed changes are just personal preferences! Happy to revert any of these changes, but I think a few of them are important for readability._

**Home page**:
- Fixed alignment of title + badge/label (e.g. "Instructions — ARROWGLACIER")
- Added letter spacing to small uppercase text for improved readability
- Fixed text colors for dark mode to improve a11y/visibility

**Playground page**:
- Fixed alignment of title + badge/label (e.g. "EVM Playground — ARROWGLACIER")
- Fixed text colors for dark mode to improve a11y/visibility

**About page**:
- Added max width to improve readability on larger screens


## Screenshots 

For comparing before vs after. (Most of the changes are subtle, see above for description of what changed!)

| Home page (before)  | Home page (after) |
| ------------- | ------------- |
|  <img width="400" alt="Screen Shot 2022-06-15 at 8 43 54 PM" src="https://user-images.githubusercontent.com/5264279/173967340-e19e22b1-a744-47f1-87ef-c581aea76d05.png">  | <img width="400" alt="Screen Shot 2022-06-15 at 8 51 16 PM" src="https://user-images.githubusercontent.com/5264279/173967337-768d4c34-43d6-46e2-9e73-3b238dac4542.png"> |

| Playground page (before)  | Playground page (after) |
| ------------- | ------------- |
|  <img width="400" alt="Screen Shot 2022-06-15 at 8 51 35 PM" src="https://user-images.githubusercontent.com/5264279/173967334-0904129d-b0af-4cdc-a84c-f444c1410b2a.png">  | <img width="400" alt="Screen Shot 2022-06-15 at 8 51 37 PM" src="https://user-images.githubusercontent.com/5264279/173967331-967212cc-8bd4-4ded-8189-7b6002a7c5ab.png"> |

| About page (before)  | About page (after) |
| ------------- | ------------- |
|  <img width="400" alt="Screen Shot 2022-06-15 at 8 51 52 PM" src="https://user-images.githubusercontent.com/5264279/173967329-3901b037-cc17-405d-9e75-4ced973426f6.png">  | <img width="400" alt="Screen Shot 2022-06-15 at 8 51 57 PM" src="https://user-images.githubusercontent.com/5264279/173967325-de8b702e-8dc1-4681-a878-3e8e4f1681af.png">
 |


