### PR TITLE
[chore] add opcode id show.

### DIFF
--- a/components/Editor/InstructionRow.tsx
+++ b/components/Editor/InstructionRow.tsx
@@ -2,6 +2,8 @@ import { useState, forwardRef, ForwardedRef, useCallback } from 'react'
 
 import cn from 'classnames'
 
+import { toHex } from '../../util/string'
+
 type RowProps = {
   instructionId: number
   isActive: boolean
@@ -49,7 +51,8 @@ const EditorInstructionRow = forwardRef(
         )}
         ref={ref}
       >
-        <td className="py-1 pl-6 pr-6">
+        <td className="py-1 pl-6 pr-3">[{toHex(instructionId)}]</td>
+        <td className="py-1 pl-3 pr-6">
           {(isBreakpointVisible || hasBreakpoint) && (
             <button
               onClick={toggleBreakpoint}


### PR DESCRIPTION
We should add the opcode id in the Instruction row, so we can trace the next opcode id when the current opcode is```JUMP``` or ```JUMPI```.

![CleanShot 2022-06-18 at 10 59 23](https://user-images.githubusercontent.com/101780038/174420095-6f8bd149-e003-4075-87fb-d546b52284e0.png)
