### PR TITLE
chore: fix the playground example for CREATE

### DIFF
--- a/docs/opcodes/F0.mdx
+++ b/docs/opcodes/F0.mdx
@@ -35,7 +35,7 @@ Note that these failures only affect the return value and do not cause the calli
 
 ## Examples
 
-[See in playground](/playground?callValue=9&unit=Wei&codeType=Mnemonic&code='z0q0f9q9f0y4%20FFmslk3%200x63FFFFFFFF60005260046000F3jvMSTORE~13jjp%20'~k%20z%2F%2F%20Createmnmccountgith%20ygeimnd%20v%5Cnqynoljj~pvCREATEm%20al%20codekvPUSH1j~0g%20wfpvvz%01fgjklmpqvyz~_).
+[See in playground](/playground?callValue=9&unit=Wei&codeType=Mnemonic&code='z0q0f9q9f0y4%20FFmslk3%200x63FFFFFFFF6000526004601CF3jvMSTORE~13jjp%20'~k%20z%2F%2F%20Createmnmccountgith%20ygeimnd%20v%5Cnqynoljj~pvCREATEm%20al%20codekvPUSH1j~0g%20wfpvvz%01fgjklmpqvyz~_).
 
 ## Error cases
 


### PR DESCRIPTION
The bytecode `0x63FFFFFFFF60005260046000F3` that is deployed in the 3rd CREATE in the CREATE playground is strange in the sense that it PUSHes `0xFFFFFF` on stack, MSTOREs it and returns 4 bytes (RETURN instruction with offset 0 and size 4). However this returns `0x000000`. This isn't a mistake per se, it seems like a typo where the intent was to return the 4 bytes previously MSTOREd.

This pull request changes the bytecode to `63FFFFFFFF6000526004601CF3` so that the returned bytecode coincides with the 4 bytes previouslypushed on stack. 