### PR TITLE
Fix specification error

### DIFF
--- a/docs/precompiled/0x01.mdx
+++ b/docs/precompiled/0x01.mdx
@@ -13,7 +13,7 @@ More information about ECDSA can be found [here](https://en.wikipedia.org/wiki/E
 | `[0; 31]` (32 bytes) | hash | Keccack-256 hash of the transaction |
 | `[32; 63]` (32 bytes) | v | Recovery identifier, expected to be either 27 or 28 |
 | `[64; 95]` (32 bytes) | r | x-value, expected to be in the range `]0; secp256k1n[` |
-| `[96; 127]` (32 bytes) | s | Expected to be in the range `]0; secp256k1n / 2 + 1[` |
+| `[96; 127]` (32 bytes) | s | Expected to be in the range `]0; secp256k1n[` |
 
 ## Output
 


### PR DESCRIPTION
The valid range for s is ]0, secp256k1n[, as can be checked in the [playground](https://www.evm.codes/playground?unit=Wei&codeType=Mnemonic&code='jFirsNplace_parameters%20in%20memoryZ456e9aea5e197a1f1af7a3e85a3212fa4049a3ba34c2289b4c860fc0b0c64ef3whash~Y~27wvX2YZ9242685bf161793cc25603c231bc2f568eb630ea16aa137d2664ac8038825608wrX4YZb0751c428acadb72f42bb7d6733d1df79c5843b9a7d3c407b39bd3a37fb11667wsX6YqqjDo_call~32JSizeX80JOffsetX8VSize~VOffset~1waddressW4QFFFFFFFFwgasqSTATICCALLqqjPut_resulNalonKon_stackqPOPX80qMLOAD'~W1%20w%20jq%5Cnj%2F%2F%20_%20thKZW32QY0qMSTOREX~0xWqPUSHV0wargsQ%200xNt%20Ke%20Jwret%01JKNQVWXYZ_jqw~_). The playground example I am linking in particular is the same signature as the example provided on evm.codes but with `s' = secp256k1n - s` and `v` flipped (27 instead of 28), which is a valid signature and returns the same address.

Formula (210) on the yellow paper appendix E confirms the bounds on valid s are `]0, secp256k1n[`. Formula (311) bounds `s < secp256k1n / 2 + 1` only for the case of transaction signature validity.

Best!