### PR TITLE
Move ownership verfication file

### DIFF
--- a/google36538dd7d1ae8edc.html
+++ b/google36538dd7d1ae8edc.html
@@ -1,1 +1,0 @@
-google-site-verification: google36538dd7d1ae8edc.html

--- a/public/google36538dd7d1ae8edc.html
+++ b/public/google36538dd7d1ae8edc.html
@@ -1,0 +1,1 @@
+google-site-verification: google36538dd7d1ae8edc.html


### PR DESCRIPTION
Google ownership verification file needs to be in public directory to be legible to Google's verification service