### PR TITLE
Fix byte range of `ecadd` precompile

### DIFF
--- a/docs/precompiled/0x06.mdx
+++ b/docs/precompiled/0x06.mdx
@@ -13,7 +13,7 @@ The point at infinity is encoded with both field `x` and `y` at `0`.
 | `[0; 31]` (32 bytes) | x1 | X coordinate of the first point on the elliptic curve 'alt_bn128'|
 | `[32; 63]` (32 bytes) | y1 | Y coordinate of the first point on the elliptic curve 'alt_bn128' |
 | `[64; 95]` (32 bytes) | x2 | X coordinate of the second point on the elliptic curve 'alt_bn128' |
-| `[64; 95]` (32 bytes) | y2 | Y coordinate of the second point on the elliptic curve 'alt_bn128' |
+| `[96; 128]` (32 bytes) | y2 | Y coordinate of the second point on the elliptic curve 'alt_bn128' |
 
 ## Output
 


### PR DESCRIPTION
#141 fixed a typo of the mislabeled point y2, but missed the byte range