### PR TITLE
Fix typo in byte range of precompiled contracts

### DIFF
--- a/docs/precompiled/0x03.mdx
+++ b/docs/precompiled/0x03.mdx
@@ -6,7 +6,7 @@ fork: Frontier
 
 | Byte range | Name | Description |
 |-----------:|-----:|------------:|
-| `[0; length[` | data | Data to hash with RIPEMD-160 |
+| `[0; length]` | data | Data to hash with RIPEMD-160 |
 
 ## Output
 

--- a/docs/precompiled/0x04.mdx
+++ b/docs/precompiled/0x04.mdx
@@ -10,13 +10,13 @@ The identity function is typically used to copy a chunk of memory.
 
 | Byte range | Name | Description |
 |-----------:|-----:|------------:|
-| `[0; length[` | data | Data to return |
+| `[0; length]` | data | Data to return |
 
 ## Output
 
 | Byte range | Name | Description |
 |-----------:|-----:|------------:|
-| `[0; length[` | data | Data from input |
+| `[0; length]` | data | Data from input |
 
  If not enough gas was given, then there is no return data.
 


### PR DESCRIPTION
Changed from `[0; length[` to `[0; length]`