### PR TITLE
Add fork to query params

### DIFF
--- a/components/ChainSelector.tsx
+++ b/components/ChainSelector.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useMemo, useState, useCallback } from 'react'
 
-import { useRouter } from 'next/router'
 import { useRegisterActions, Action } from 'kbar'
+import { useRouter } from 'next/router'
 import Select, { OnChangeValue, components } from 'react-select'
 
 import { EthereumContext } from 'context/ethereumContext'
@@ -51,6 +51,7 @@ const ChainSelector = () => {
       router.query.fork = option.value
       router.push(router)
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [onForkChange, setSetting],
   )
 

--- a/components/ChainSelector.tsx
+++ b/components/ChainSelector.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useMemo, useState, useCallback } from 'react'
 
+import { useRouter } from 'next/router'
 import { useRegisterActions, Action } from 'kbar'
 import Select, { OnChangeValue, components } from 'react-select'
 
@@ -29,6 +30,7 @@ const ChainSelector = () => {
 
   const [forkValue, setForkValue] = useState()
   const [actions, setActions] = useState<Action[]>([])
+  const router = useRouter()
 
   const forkOptions = useMemo(
     () => forks.map((fork) => ({ value: fork.name, label: fork.name })),
@@ -45,6 +47,9 @@ const ChainSelector = () => {
       setForkValue(option)
       onForkChange(option.value)
       setSetting(Setting.VmFork, option.value)
+
+      router.query.fork = option.value
+      router.push(router)
     },
     [onForkChange, setSetting],
   )

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -399,7 +399,7 @@ const Editor = ({ readOnly = false }: Props) => {
     }
 
     copy(`${getAbsoluteURL('/playground')}?${objToQueryString(params)}`)
-    log('Link to current code, calldata and value copied to clipboard')
+    log('Link to current fork, code, calldata and value copied to clipboard')
   }, [selectedFork, callValue, unit, callData, codeType, code, log])
 
   const isRunDisabled = useMemo(() => {

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -388,7 +388,9 @@ const Editor = ({ readOnly = false }: Props) => {
   ])
 
   const handleCopyPermalink = useCallback(() => {
+    const fork = selectedFork?.name
     const params = {
+      fork,
       callValue,
       unit,
       callData,
@@ -398,7 +400,7 @@ const Editor = ({ readOnly = false }: Props) => {
 
     copy(`${getAbsoluteURL('/playground')}?${objToQueryString(params)}`)
     log('Link to current code, calldata and value copied to clipboard')
-  }, [callValue, unit, callData, codeType, code, log])
+  }, [selectedFork, callValue, unit, callData, codeType, code, log])
 
   const isRunDisabled = useMemo(() => {
     return compiling || isEmpty(code)

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -81,6 +81,7 @@ const Editor = ({ readOnly = false }: Props) => {
     opcodes,
     instructions,
     resetExecution,
+    onForkChange,
   } = useContext(EthereumContext)
 
   const [code, setCode] = useState('')
@@ -225,6 +226,11 @@ const Editor = ({ readOnly = false }: Props) => {
 
       setCodeType(initialCodeType)
       setCode(examples[initialCodeType][0])
+    }
+
+    if ('fork' in query) {
+      onForkChange(query.fork as string)
+      setSetting(Setting.VmFork, query.fork as string)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settingsLoaded && router.isReady])

--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -233,8 +233,8 @@ const ReferenceTable = ({
                           <Link
                             href={
                               isPrecompiled
-                                ? `/precompiled#${opcodeOrAddress}`
-                                : `/#${opcodeOrAddress}`
+                                ? `/precompiled#${opcodeOrAddress}?fork=${selectedFork?.name}`
+                                : `/#${opcodeOrAddress}?fork=${selectedFork?.name}`
                             }
                             passHref
                           >

--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -102,6 +102,7 @@ const ReferenceTable = ({
       onForkChange(query.fork as string)
       setSetting(Setting.VmFork, query.fork as string)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.isReady])
 
   const renderExpandButton = () => {

--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -16,6 +16,7 @@ import ReactTooltip from 'react-tooltip'
 import { IReferenceItem, IItemDocs, IGasDocs } from 'types'
 
 import { EthereumContext } from 'context/ethereumContext'
+import { SettingsContext, Setting } from 'context/settingsContext'
 
 import { findMatchingForkName } from 'util/gas'
 
@@ -42,7 +43,8 @@ const ReferenceTable = ({
   isPrecompiled?: boolean
 }) => {
   const router = useRouter()
-  const { forks, selectedFork } = useContext(EthereumContext)
+  const { forks, selectedFork, onForkChange } = useContext(EthereumContext)
+  const { setSetting } = useContext(SettingsContext)
   const data = useMemo(() => reference, [reference])
   const columns = useMemo(() => tableColumns(isPrecompiled), [isPrecompiled])
   const rowRefs = useRef<HTMLTableRowElement[]>([])
@@ -91,6 +93,16 @@ const ReferenceTable = ({
       }
     }
   }, [reference, router.asPath])
+
+  // Change selectedFork according to query param
+  useEffect(() => {
+    const query = router.query
+
+    if ('fork' in query) {
+      onForkChange(query.fork as string)
+      setSetting(Setting.VmFork, query.fork as string)
+    }
+  }, [router.isReady])
 
   const renderExpandButton = () => {
     return (

--- a/pages/precompiled.tsx
+++ b/pages/precompiled.tsx
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
-import React, { useContext } from 'react'
+import React, { useContext, useEffect } from 'react'
 
 import matter from 'gray-matter'
 import type { NextPage } from 'next'
@@ -11,11 +11,13 @@ import Head from 'next/head'
 import { IItemDocs, IGasDocs, IDocMeta } from 'types'
 
 import { EthereumContext } from 'context/ethereumContext'
+import { SettingsContext, Setting } from 'context/settingsContext'
 
 import ContributeBox from 'components/ContributeBox'
 import HomeLayout from 'components/layouts/Home'
 import ReferenceTable from 'components/Reference'
 import { H1, H2, Container, RelativeLink as Link } from 'components/ui'
+import { useRouter } from 'next/router'
 
 const { serverRuntimeConfig } = getConfig()
 
@@ -27,7 +29,20 @@ const PrecompiledPage = ({
   precompiledDocs: IItemDocs
   gasDocs: IGasDocs
 }) => {
-  const { precompiled } = useContext(EthereumContext)
+  const { precompiled, onForkChange } = useContext(EthereumContext)
+  const { setSetting } = useContext(SettingsContext)
+
+    // Change selectedFork according to query param
+    const router = useRouter()
+
+    useEffect(() => {
+      const query = router.query
+  
+      if ('fork' in query) {
+        onForkChange(query.fork as string)
+        setSetting(Setting.VmFork, query.fork as string)
+      }
+    }, [router.isReady])
 
   return (
     <>

--- a/pages/precompiled.tsx
+++ b/pages/precompiled.tsx
@@ -8,6 +8,7 @@ import type { NextPage } from 'next'
 import { serialize } from 'next-mdx-remote/serialize'
 import getConfig from 'next/config'
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 import { IItemDocs, IGasDocs, IDocMeta } from 'types'
 
 import { EthereumContext } from 'context/ethereumContext'
@@ -17,7 +18,6 @@ import ContributeBox from 'components/ContributeBox'
 import HomeLayout from 'components/layouts/Home'
 import ReferenceTable from 'components/Reference'
 import { H1, H2, Container, RelativeLink as Link } from 'components/ui'
-import { useRouter } from 'next/router'
 
 const { serverRuntimeConfig } = getConfig()
 
@@ -32,17 +32,18 @@ const PrecompiledPage = ({
   const { precompiled, onForkChange } = useContext(EthereumContext)
   const { setSetting } = useContext(SettingsContext)
 
-    // Change selectedFork according to query param
-    const router = useRouter()
+  // Change selectedFork according to query param
+  const router = useRouter()
 
-    useEffect(() => {
-      const query = router.query
-  
-      if ('fork' in query) {
-        onForkChange(query.fork as string)
-        setSetting(Setting.VmFork, query.fork as string)
-      }
-    }, [router.isReady])
+  useEffect(() => {
+    const query = router.query
+
+    if ('fork' in query) {
+      onForkChange(query.fork as string)
+      setSetting(Setting.VmFork, query.fork as string)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady])
 
   return (
     <>


### PR DESCRIPTION
See this [issue](https://github.com/comitylabs/evm.codes/issues/84)

Added the option to provide a `fork` query parameter to the following pages:

- Precompiles
- Playground
- Reference Table

Also added the `fork` query parameter to the permalink copy feature of Playground.