### PR TITLE
updated all reference of /about to the correct internal section of the about page

### DIFF
--- a/docs/opcodes/00.mdx
+++ b/docs/opcodes/00.mdx
@@ -5,6 +5,6 @@ group: Stop and Arithmetic Operations
 
 ## Notes
 
-Exits the current [context](/about) successfully.
+Exits the current [context](/about#executionenv) successfully.
 
 When a call is executed on an address with no code and the EVM tries to read the code data, the default value is returned, 0, which corresponds to this instruction and halts the execution.

--- a/docs/opcodes/20/homestead.mdx
+++ b/docs/opcodes/20/homestead.mdx
@@ -5,4 +5,4 @@
     static_gas = {gasPrices|sha3}
     dynamic_gas = {gasPrices|sha3Word} * minimum_word_size + memory_expansion_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/31/berlin.mdx
+++ b/docs/opcodes/31/berlin.mdx
@@ -1,3 +1,3 @@
 ## Gas
 
-The static cost is {gasPrices|balance}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldaccountaccess}. See section [access sets](/about).
+The static cost is {gasPrices|balance}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldaccountaccess}. See section [access sets](/about#accesssets).

--- a/docs/opcodes/35.mdx
+++ b/docs/opcodes/35.mdx
@@ -3,34 +3,35 @@ fork: Frontier
 group: Environmental Information
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Stack input
 
-0. `i`: byte offset in the [calldata](/about).
+0. `i`: byte offset in the [calldata](/about#calldata).
 
 ## Stack output
 
-0. `data[i]`: 32-byte value starting from the given offset of the [calldata](/about). All bytes after the end of the [calldata](/about) are set to 0.
+0. `data[i]`: 32-byte value starting from the given offset of the [calldata](/about#calldata). All bytes after the end of the [calldata](/about#calldata) are set to 0.
 
 ## Examples
 
-| Calldata |
-|---------|
+| Calldata                                                             |
+| -------------------------------------------------------------------- |
 | `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 
-| * | Input | Output |
-|--:|------:|-------:|
-| `1` | `0` | `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
+|  \* | Input |                                                               Output |
+| --: | ----: | -------------------------------------------------------------------: |
+| `1` |   `0` | `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 
-| * | Input | Output |
-|--:|------:|-------:|
-| `1` | `31` | `0xFF00000000000000000000000000000000000000000000000000000000000000` |
+|  \* | Input |                                                               Output |
+| --: | ----: | -------------------------------------------------------------------: |
+| `1` |  `31` | `0xFF00000000000000000000000000000000000000000000000000000000000000` |
 
 [Reproduce in playground](/playground?unit=Wei&callData=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF&codeType=Mnemonic&code='~1w0yzz~2w31y'~%2F%2F%20Example%20z%5CnyzCALLDATALOADwzPUSH1%20%01wyz~_).
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/36.mdx
+++ b/docs/opcodes/36.mdx
@@ -3,26 +3,27 @@ fork: Frontier
 group: Environmental Information
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Stack output
 
-0. `size`: byte size of the [calldata](/about).
+0. `size`: byte size of the [calldata](/about#calldata).
 
 ## Example
 
 | Calldata |
-|---------|
-| `0xFF` |
+| -------- |
+| `0xFF`   |
 
-| * | Input | Output |
-|--:|------:|-------:|
-| `1` | | `1` |
+|  \* | Input | Output |
+| --: | ----: | -----: |
+| `1` |       |    `1` |
 
 [Reproduce in playground](/playground?unit=Wei&callData=0xFF&codeType=Mnemonic&code='CALLDATASIZE'_).
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Stack overflow.

--- a/docs/opcodes/37.mdx
+++ b/docs/opcodes/37.mdx
@@ -3,7 +3,7 @@ fork: Frontier
 group: Environmental Information
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
@@ -11,32 +11,32 @@ For out of bound bytes, 0s will be copied.
 
 ## Stack input
 
-0. `destOffset`: byte offset in the [memory](/about) where the result will be copied.
-1. `offset`: byte offset in the [calldata](/about) to copy.
+0. `destOffset`: byte offset in the [memory](/about#memory) where the result will be copied.
+1. `offset`: byte offset in the [calldata](/about#calldata) to copy.
 2. `size`: byte size to copy.
 
 ## Examples
 
-| Calldata |
-|---------:|
+|                                                             Calldata |
+| -------------------------------------------------------------------: |
 | `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 
-| * | Input 1 | * | * | Input 2 |
-|--:|--------:|--:|--:|--------:|
-| `1` | `0` | * | `1` | `0` |
-| `2` | `0` | * | `2` | `31` |
-| `3` | `32` | * | `3` | `8` |
+|  \* | Input 1 |  \* |  \* | Input 2 |
+| --: | ------: | --: | --: | ------: |
+| `1` |     `0` |  \* | `1` |     `0` |
+| `2` |     `0` |  \* | `2` |    `31` |
+| `3` |    `32` |  \* | `3` |     `8` |
 
 | Memory before |
-|-------------:|
-| `0` |
+| ------------: |
+|           `0` |
 
-| Memory after input 1 |
-|---------------------:|
+|                                                 Memory after input 1 |
+| -------------------------------------------------------------------: |
 | `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 
-| Memory after input 1 then 2 |
-|----------------------------:|
+|                                          Memory after input 1 then 2 |
+| -------------------------------------------------------------------: |
 | `0xFF00000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 
 [Reproduce in playground](/playground?unit=Wei&callData=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF&codeType=Mnemonic&code='z1~32~0ywwz2~8~31y'~wPUSH1%20z%2F%2F%20Example%20y~0wCALLDATACOPYw%5Cn%01wyz~_).
@@ -44,5 +44,6 @@ For out of bound bytes, 0s will be copied.
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/37/homestead.mdx
+++ b/docs/opcodes/37/homestead.mdx
@@ -5,4 +5,4 @@
     static_gas = {gasPrices|calldatacopy}
     dynamic_gas = {gasPrices|copy} * minimum_word_size + memory_expansion_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/38.mdx
+++ b/docs/opcodes/38.mdx
@@ -3,7 +3,7 @@ fork: Frontier
 group: Environmental Information
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
@@ -11,18 +11,19 @@ Each instruction occupies one byte. In the case of a [PUSH](/#60) instruction, t
 
 ## Stack output
 
-0. `size`: byte size of the [code](/about).
+0. `size`: byte size of the [code](/about#code).
 
 ## Example
 
-| * | Input | Output |
-|--:|------:|-------:|
-| `1` | | `32` |
+|  \* | Input | Output |
+| --: | ----: | -----: |
+| `1` |       |   `32` |
 
 [Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='%2F%2F%20Add%20som~instructions%20to%20increas~th~cod~sizeyPUSH29%200yPOPyyCODESIZE'~e%20y%5Cn%01y~_).
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Stack overflow.

--- a/docs/opcodes/39.mdx
+++ b/docs/opcodes/39.mdx
@@ -3,7 +3,7 @@ fork: Frontier
 group: Environmental Information
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
@@ -11,32 +11,32 @@ For out of bound bytes, 0s will be copied.
 
 ## Stack input
 
-0. `destOffset`: byte offset in the [memory](/about) where the result will be copied.
-1. `offset`: byte offset in the [code](/about) to copy.
+0. `destOffset`: byte offset in the [memory](/about#memory) where the result will be copied.
+1. `offset`: byte offset in the [code](/about#code) to copy.
 2. `size`: byte size to copy.
 
 ## Examples
 
-| Code |
-|-----:|
+|                                                                 Code |
+| -------------------------------------------------------------------: |
 | `0x7DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7F` |
 
-| * | Input 1 | * | * | Input 2 |
-|--:|--------:|--:|--:|--------:|
-| `1` | `0` | * | `1` | `0` |
-| `2` | `0` | * | `2` | `31` |
-| `3` | `32` | * | `3` | `8` |
+|  \* | Input 1 |  \* |  \* | Input 2 |
+| --: | ------: | --: | --: | ------: |
+| `1` |     `0` |  \* | `1` |     `0` |
+| `2` |     `0` |  \* | `2` |    `31` |
+| `3` |    `32` |  \* | `3` |     `8` |
 
 | Memory before |
-|--------------:|
-| `0` |
+| ------------: |
+|           `0` |
 
-| Memory after input 1 |
-|---------------------:|
+|                                                 Memory after input 1 |
+| -------------------------------------------------------------------: |
 | `0x7DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7F` |
 
-| Memory after input 1 then 2 |
-|----------------------------:|
+|                                          Memory after input 1 then 2 |
+| -------------------------------------------------------------------: |
 | `0x7F00000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7F` |
 
 [Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='qPutwbeginning%20ofwcodXtowexpected%20valueZ30VxWWWWWZ32VyyqRemovewvalues%20fromwstackTTj1~32~0_j2~8~31_'~Z1%20zFFFFFFy%5Cnw%20thXq%2F%2F%20jyyqExamplX_~0yCODECOPYZyPUSHXe%20WzzV%200TyPOP%01TVWXZ_jqwyz~_).
@@ -44,5 +44,6 @@ For out of bound bytes, 0s will be copied.
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/39/homestead.mdx
+++ b/docs/opcodes/39/homestead.mdx
@@ -5,4 +5,4 @@
     static_gas = {gasPrices|codecopy}
     dynamic_gas = {gasPrices|copy} * minimum_word_size + memory_expansion_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/3B.mdx
+++ b/docs/opcodes/3B.mdx
@@ -3,7 +3,7 @@ fork: Frontier
 group: Environmental Information
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Stack input
 
@@ -11,13 +11,13 @@ group: Environmental Information
 
 ## Stack output
 
-0. `size`: byte size of the [code](/about).
+0. `size`: byte size of the [code](/about#code).
 
 ## Example
 
-| * | Input | Output |
-|--:|------:|-------:|
-| `1` | `0x43a61f3f4c73ea0d444c5c1c1a8544067a86219b` | `32` |
+|  \* |                                        Input | Output |
+| --: | -------------------------------------------: | -----: |
+| `1` | `0x43a61f3f4c73ea0d444c5c1c1a8544067a86219b` |   `32` |
 
 [Reproduce in playground][1].
 
@@ -26,5 +26,6 @@ group: Environmental Information
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/3B/berlin.mdx
+++ b/docs/opcodes/3B/berlin.mdx
@@ -1,3 +1,3 @@
 ## Gas
 
-The static cost is {gasPrices|extcodesize}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldaccountaccess}. See section [access sets](/about).
+The static cost is {gasPrices|extcodesize}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldaccountaccess}. See section [access sets](/about#accesssets).

--- a/docs/opcodes/3C.mdx
+++ b/docs/opcodes/3C.mdx
@@ -3,7 +3,7 @@ fork: Frontier
 group: Environmental Information
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
@@ -12,33 +12,33 @@ For out of bound bytes, 0s will be copied.
 ## Stack input
 
 0. `address`: 20-byte address of the contract to query.
-1. `destOffset`: byte offset in the [memory](/about) where the result will be copied.
-2. `offset`: byte offset in the [code](/about) to copy.
+1. `destOffset`: byte offset in the [memory](/about#memory) where the result will be copied.
+2. `offset`: byte offset in the [code](/about#code) to copy.
 3. `size`: byte size to copy.
 
 ## Examples
 
-| Code |
-|-----:|
-|`0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
-
-| * | Input 1 | * | * | Input 2 |
-|--:|--------:|--:|--:|--------:|
-| `1` | `0x43a61f3f4c73ea0d444c5c1c1a8544067a86219b` | * | `1` | `0x43a61f3f4c73ea0d444c5c1c1a8544067a86219b` |
-| `2` | `0` | * | `2` | `0` |
-| `3` | `0` | * | `3` | `31` |
-| `4` | `32` | * | `4` | `8` |
-
-| Memory before |
-|--------------:|
-| `0` |
-
-| Memory after input 1 |
-|---------------------:|
+|                                                                 Code |
+| -------------------------------------------------------------------: |
 | `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 
-| Memory after input 1 then 2 |
-|----------------------------:|
+|  \* |                                      Input 1 |  \* |  \* |                                      Input 2 |
+| --: | -------------------------------------------: | --: | --: | -------------------------------------------: |
+| `1` | `0x43a61f3f4c73ea0d444c5c1c1a8544067a86219b` |  \* | `1` | `0x43a61f3f4c73ea0d444c5c1c1a8544067a86219b` |
+| `2` |                                          `0` |  \* | `2` |                                          `0` |
+| `3` |                                          `0` |  \* | `3` |                                         `31` |
+| `4` |                                         `32` |  \* | `4` |                                          `8` |
+
+| Memory before |
+| ------------: |
+|           `0` |
+
+|                                                 Memory after input 1 |
+| -------------------------------------------------------------------: |
+| `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
+
+|                                          Memory after input 1 then 2 |
+| -------------------------------------------------------------------: |
 | `0xFF00000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 
 [Reproduce in playground][1]
@@ -48,5 +48,6 @@ For out of bound bytes, 0s will be copied.
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/3C/berlin.mdx
+++ b/docs/opcodes/3C/berlin.mdx
@@ -5,5 +5,5 @@
     static_gas = {gasPrices|extcodecopy}
     dynamic_gas = {gasPrices|copy} * minimum_word_size + memory_expansion_cost + address_access_cost
 
-The memory expansion cost explanation can be found [here](/about).
-If the accessed address is warm, `address_access_cost` is {gasPrices|warmstorageread}, otherwise it is {gasPrices|coldaccountaccess}. See section [access sets](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
+If the accessed address is warm, `address_access_cost` is {gasPrices|warmstorageread}, otherwise it is {gasPrices|coldaccountaccess}. See section [access sets](/about#accesssets).

--- a/docs/opcodes/3C/homestead.mdx
+++ b/docs/opcodes/3C/homestead.mdx
@@ -5,4 +5,4 @@
     static_gas = {gasPrices|extcodecopy}
     dynamic_gas = {gasPrices|copy} * minimum_word_size + memory_expansion_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/3D.mdx
+++ b/docs/opcodes/3D.mdx
@@ -3,7 +3,7 @@ fork: Byzantium
 group: Environmental Information
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
@@ -11,13 +11,13 @@ A sub context can be created with [CALL](/#F1), [CALLCODE](/#F2), [DELEGATECALL]
 
 ## Stack output
 
-0. `size`: byte size of the [return data](/about) from the last executed sub [context](/about).
+0. `size`: byte size of the [return data](/about#returndata) from the last executed sub [context](/about#executionenv).
 
 ## Example
 
-| * | Input | Output |
-|--:|------:|-------:|
-| `1` | | `32` |
+|  \* | Input | Output |
+| --: | ----: | -----: |
+| `1` |       |   `32` |
 
 [Reproduce in playground][1]
 
@@ -26,5 +26,6 @@ A sub context can be created with [CALL](/#F1), [CALLCODE](/#F2), [DELEGATECALL]
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Stack overflow.

--- a/docs/opcodes/3E.mdx
+++ b/docs/opcodes/3E.mdx
@@ -3,7 +3,7 @@ fork: Byzantium
 group: Environmental Information
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
@@ -11,32 +11,32 @@ A sub context can be created with [CALL](/#F1), [CALLCODE](/#F2), [DELEGATECALL]
 
 ## Stack input
 
-0. `destOffset`: byte offset in the [memory](/about) where the result will be copied.
-1. `offset`: byte offset in the [return data](/about) from the last executed sub [context](/about) to copy.
+0. `destOffset`: byte offset in the [memory](/about#memory) where the result will be copied.
+1. `offset`: byte offset in the [return data](/about#returndata) from the last executed sub [context](/about#executionenv) to copy.
 2. `size`: byte size to copy.
 
 ## Examples
 
-| Return data |
-|------------:|
+|                                                          Return data |
+| -------------------------------------------------------------------: |
 | `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 
-| * | Input 1 | * | * | Input 2 |
-|--:|--------:|--:|--:|--------:|
-| `1` | `0` | * | `1` | `32` |
-| `2` | `0` | * | `2` | `31` |
-| `3` | `32` | * | `3` | `1` |
+|  \* | Input 1 |  \* |  \* | Input 2 |
+| --: | ------: | --: | --: | ------: |
+| `1` |     `0` |  \* | `1` |    `32` |
+| `2` |     `0` |  \* | `2` |    `31` |
+| `3` |    `32` |  \* | `3` |     `1` |
 
 | Memory before |
-|--------------:|
-| `0` |
+| ------------: |
+|           `0` |
 
-| Memory after input 1 |
-|---------------------:|
+|                                                 Memory after input 1 |
+| -------------------------------------------------------------------: |
 | `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 
-| Memory after input 1 then 2 |
-|----------------------------:|
+|                                            Memory after input 1 then 2 |
+| ---------------------------------------------------------------------: |
 | `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 
 [Reproduce in playground][1]
@@ -46,6 +46,7 @@ A sub context can be created with [CALL](/#F1), [CALLCODE](/#F2), [DELEGATECALL]
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - Reading offset equal of higher than [RETURNDATASIZE](#3D).

--- a/docs/opcodes/3E/homestead.mdx
+++ b/docs/opcodes/3E/homestead.mdx
@@ -5,4 +5,4 @@
     static_gas = {gasPrices|returndatacopy}
     dynamic_gas = {gasPrices|copy} * minimum_word_size + memory_expansion_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/3F.mdx
+++ b/docs/opcodes/3F.mdx
@@ -3,7 +3,7 @@ fork: Constantinople
 group: Environmental Information
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Stack input
 
@@ -11,12 +11,12 @@ group: Environmental Information
 
 ## Stack output
 
-0. `hash`: hash of the chosen account's [code](/about), or 0 if the account has no [code](/about).
+0. `hash`: hash of the chosen account's [code](/about#code), or 0 if the account has no [code](/about#code).
 
 ## Examples
 
-| * | Input | Output |
-|--:|------:|-------:|
+|  \* |                                        Input |                                                               Output |
+| --: | -------------------------------------------: | -------------------------------------------------------------------: |
 | `1` | `0x43a61f3f4c73ea0d444c5c1c1a8544067a86219b` | `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470` |
 
 [Reproduce in playground][1]
@@ -26,5 +26,6 @@ group: Environmental Information
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/3F/berlin.mdx
+++ b/docs/opcodes/3F/berlin.mdx
@@ -1,3 +1,3 @@
 ## Gas
 
-The static cost is {gasPrices|extcodehash}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldaccountaccess}. See section [access sets](/about).
+The static cost is {gasPrices|extcodehash}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldaccountaccess}. See section [access sets](/about#accesssets).

--- a/docs/opcodes/51.mdx
+++ b/docs/opcodes/51.mdx
@@ -3,30 +3,31 @@ fork: Frontier
 group: Stack Memory Storage and Flow Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Stack input
 
-0. `offset`: offset in the [memory](/about) in bytes.
+0. `offset`: offset in the [memory](/about#memory) in bytes.
 
 ## Stack output
 
-0. `value`: the 32 bytes in [memory](/about) starting at that offset. If it goes beyond its current size (see [MSIZE](/#59)), writes 0s.
+0. `value`: the 32 bytes in [memory](/about#memory) starting at that offset. If it goes beyond its current size (see [MSIZE](/#59)), writes 0s.
 
 ## Examples
 
-| Memory |
-|-------:|
+|                                                               Memory |
+| -------------------------------------------------------------------: |
 | `0x00000000000000000000000000000000000000000000000000000000000000FF` |
 
-| * | Input | Output | * | * | Input | Output |
-|--:|------:|-------:|--:|--:|------:|-------:|
-| `1` | `0` | `0xFF` | * | `1` | `1` | `0xFF00` |
+|  \* | Input | Output |  \* |  \* | Input |   Output |
+| --: | ----: | -----: | --: | --: | ----: | -------: |
+| `1` |   `0` | `0xFF` |  \* | `1` |   `1` | `0xFF00` |
 
 [Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='qPut%20thkstatkin%20memoryg32%200xfffffdFFv0zMSTOREw1v0jw2v1jz'~dddz%5CnwzzqExamplkvg1%20q%2F%2F%20ke%20jzMLOADgzPUSHf~~d00%01dfgjkqvwz~_).
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/51/homestead.mdx
+++ b/docs/opcodes/51/homestead.mdx
@@ -3,4 +3,4 @@
     static_gas = {gasPrices|mload}
     dynamic_gas = memory_expansion_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/52.mdx
+++ b/docs/opcodes/52.mdx
@@ -3,30 +3,30 @@ fork: Frontier
 group: Stack Memory Storage and Flow Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Stack input
 
-0. `offset`: offset in the [memory](/about) in bytes.
-1. `value`: 32-byte value to write in the [memory](/about).
+0. `offset`: offset in the [memory](/about#memory) in bytes.
+1. `value`: 32-byte value to write in the [memory](/about#memory).
 
 ## Examples
 
-| * | Input 1 | * | * | Input 2 |
-|--:|--------:|--:|--:|--------:|
-| `1` | `0` | * | `1` | `1` |
-| `2` | `0xFF` | * | `2` | `0xFF` |
+|  \* | Input 1 |  \* |  \* | Input 2 |
+| --: | ------: | --: | --: | ------: |
+| `1` |     `0` |  \* | `1` |     `1` |
+| `2` |  `0xFF` |  \* | `2` |  `0xFF` |
 
 | Memory before |
-|--------------:|
-| `0` |
+| ------------: |
+|           `0` |
 
-| Memory after input 1 |
-|---------------------:|
+|                                                 Memory after input 1 |
+| -------------------------------------------------------------------: |
 | `0x00000000000000000000000000000000000000000000000000000000000000FF` |
 
-| Memory after input 1 then 2 |
-|----------------------------:|
+|                                            Memory after input 1 then 2 |
+| ---------------------------------------------------------------------: |
 | `0x0000000000000000000000000000000000000000000000000000000000000000FF` |
 
 [Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='z1v0wyz2v1w'~yPUSH1%20z%2F%2F%20Example%20y%5CnwyMSTOREyv~0xFF~%01vwyz~_).
@@ -34,5 +34,6 @@ group: Stack Memory Storage and Flow Operations
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/52/homestead.mdx
+++ b/docs/opcodes/52/homestead.mdx
@@ -3,4 +3,4 @@
     static_gas = {gasPrices|mstore}
     dynamic_gas = memory_expansion_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/53.mdx
+++ b/docs/opcodes/53.mdx
@@ -3,36 +3,37 @@ fork: Frontier
 group: Stack Memory Storage and Flow Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Stack input
 
-0. `offset`: offset in the [memory](/about) in bytes.
-1. `value`: 1-byte value to write in the [memory](/about) (the least significant byte of the 32-byte stack value).
+0. `offset`: offset in the [memory](/about#memory) in bytes.
+1. `value`: 1-byte value to write in the [memory](/about#memory) (the least significant byte of the 32-byte stack value).
 
 ## Examples
 
-| * | Input 1 | * | * | Input 2 |
-|--:|--------:|--:|--:|--------:|
-| `1` | `0` | * | `1` | `1` |
-| `2` | `0xFFFF` | * | `2` | `0xFF` |
+|  \* |  Input 1 |  \* |  \* | Input 2 |
+| --: | -------: | --: | --: | ------: |
+| `1` |      `0` |  \* | `1` |     `1` |
+| `2` | `0xFFFF` |  \* | `2` |  `0xFF` |
 
 | Memory before |
-|--------------:|
-| `0` |
+| ------------: |
+|           `0` |
 
 | Memory after input 1 |
-|---------------------:|
-| `0xFF` |
+| -------------------: |
+|               `0xFF` |
 
 | Memory after input 1 then 2 |
-|----------------------------:|
-| `0xFFFF` |
+| --------------------------: |
+|                    `0xFFFF` |
 
 [Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='z1v2%200xFFFFy0w~z2y0xFFy1w'~%5Cnz%2F%2F%20Example%20yv1%20w~MSTORE8~v~PUSH%01vwyz~_).
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/53/homestead.mdx
+++ b/docs/opcodes/53/homestead.mdx
@@ -3,4 +3,4 @@
     static_gas = {gasPrices|mstore8}
     dynamic_gas = memory_expansion_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/54.mdx
+++ b/docs/opcodes/54.mdx
@@ -3,11 +3,11 @@ fork: Frontier
 group: Stack Memory Storage and Flow Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Stack input
 
-0. `key`: 32-byte key in [storage](/about).
+0. `key`: 32-byte key in [storage](/about#storage).
 
 ## Stack output
 
@@ -15,18 +15,19 @@ group: Stack Memory Storage and Flow Operations
 
 ## Examples
 
-|Storage key | Storage value |
-|-----------:|--------------:|
-| `0` | `46` |
+| Storage key | Storage value |
+| ----------: | ------------: |
+|         `0` |          `46` |
 
-| * | Input | Output | * | * | Input | Output |
-|--:|------:|-------:|--:|--:|------:|-------:|
-| `1` | `0` | `46` | * | `1` | `1` | `0` |
+|  \* | Input | Output |  \* |  \* | Input | Output |
+| --: | ----: | -----: | --: | --: | ----: | -----: |
+| `1` |   `0` |   `46` |  \* | `1` |   `1` |    `0` |
 
 [Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='wSet%20up%20thrstatez46z0~SSTOREy1z0vy2z1v~'~%5Cnz~PUSH1%20y~~wExamplrw%2F%2F%20v~SLOADre%20%01rvwyz~_).
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/54/berlin.mdx
+++ b/docs/opcodes/54/berlin.mdx
@@ -1,3 +1,3 @@
 ## Gas
 
-The static cost is {gasPrices|sload}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldsload}. See section [access sets](/about).
+The static cost is {gasPrices|sload}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldsload}. See section [access sets](/about#accesssets).

--- a/docs/opcodes/55.mdx
+++ b/docs/opcodes/55.mdx
@@ -3,38 +3,39 @@ fork: Frontier
 group: Stack Memory Storage and Flow Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Stack input
 
-0. `key`: 32-byte key in [storage](/about).
+0. `key`: 32-byte key in [storage](/about#storage).
 1. `value`: 32-byte value to store.
 
 ## Examples
 
-| * | Input 1 | * | * | Input 2 |
-|--:|--------:|--:|--:|--------:|
-| `1` | `0` | * | `1` | `8965` |
-| `2` | `0xFFFF` | * | `2` | `0xFF` |
+|  \* |  Input 1 |  \* |  \* | Input 2 |
+| --: | -------: | --: | --: | ------: |
+| `1` |      `0` |  \* | `1` |  `8965` |
+| `2` | `0xFFFF` |  \* | `2` |  `0xFF` |
 
 | Storage key before | Storage value |
-|-------------------:|--------------:|
-| | |
+| -----------------: | ------------: |
+|                    |               |
 
 | Storage key after input 1 | Storage value |
-|--------------------------:|--------------:|
-| `0` | `0xFFFF` |
+| ------------------------: | ------------: |
+|                       `0` |      `0xFFFF` |
 
 | Storage key after input 1 then 2 | Storage value |
-|---------------------------------:|--------------:|
-| `0` | `0xFFFF` |
-| `8965` | `0xFF` |
+| -------------------------------: | ------------: |
+|                              `0` |      `0xFFFF` |
+|                           `8965` |        `0xFF` |
 
 [Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='z1uFFv1%200w~z2uy8965w'~%5Cnz%2F%2F%20Example%20yv2%20w~SSTORE~v~PUSHuy0xFF%01uvwyz~_).
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).

--- a/docs/opcodes/55/berlin.mdx
+++ b/docs/opcodes/55/berlin.mdx
@@ -1,27 +1,27 @@
 ## Gas
 
 ### Definitions:
+
 - **value**: value from the stack input.
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
+  static_gas = {gasPrices|sstore}
 
-    static_gas = {gasPrices|sstore}
+  if value == current_value
+  if key is warm
+  base_dynamic_gas = {gasPrices|warmstorageread}
+  else
+  base_dynamic_gas = {gasPrices|sstoreNoopGasEIP2200}
+  else if current_value == original_value
+  if original_value == 0
+  base_dynamic_gas = {gasPrices|sstoreInitGasEIP2200}
+  else
+  base_dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
+  else
+  base_dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
 
-    if value == current_value
-        if key is warm
-            base_dynamic_gas = {gasPrices|warmstorageread}
-        else
-            base_dynamic_gas = {gasPrices|sstoreNoopGasEIP2200}
-    else if current_value == original_value
-        if original_value == 0
-            base_dynamic_gas = {gasPrices|sstoreInitGasEIP2200}
-        else
-            base_dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
-    else
-        base_dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
-
-On top of the cost above, {gasPrices|coldsload} is added to `base_dynamic_gas` if the slot is cold. See section [access sets](/about).
+On top of the cost above, {gasPrices|coldsload} is added to `base_dynamic_gas` if the slot is cold. See section [access sets](/about#accesssets).
 
 ## Gas refunds
 
@@ -47,4 +47,4 @@ On top of the cost above, {gasPrices|coldsload} is added to `base_dynamic_gas` i
                     else
                         gas_refunds += {gasPrices|sstoreCleanRefundEIP2200}
 
-See [gas refunds](/about).
+See [gas refunds](/about#gasrefunds).

--- a/docs/opcodes/55/constantinople.mdx
+++ b/docs/opcodes/55/constantinople.mdx
@@ -1,22 +1,22 @@
 ## Gas
 
 ### Definitions:
+
 - **value**: value from the stack input.
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
+  static_gas = {gasPrices|sstore}
 
-    static_gas = {gasPrices|sstore}
-
-    if value == current_value
-        dynamic_gas = {gasPrices|netSstoreNoopGas}
-    else if current_value == original_value
-        if original_value == 0
-            dynamic_gas = {gasPrices|netSstoreInitGas}
-        else
-            dynamic_gas = {gasPrices|netSstoreCleanGas}
-    else
-        dynamic_gas = {gasPrices|netSstoreDirtyGas}
+  if value == current_value
+  dynamic_gas = {gasPrices|netSstoreNoopGas}
+  else if current_value == original_value
+  if original_value == 0
+  dynamic_gas = {gasPrices|netSstoreInitGas}
+  else
+  dynamic_gas = {gasPrices|netSstoreCleanGas}
+  else
+  dynamic_gas = {gasPrices|netSstoreDirtyGas}
 
 ## Gas refunds
 
@@ -36,4 +36,4 @@
                 else
                     gas_refunds += {gasPrices|netSstoreResetRefund}
 
-See [gas refunds](/about).
+See [gas refunds](/about#gasrefunds).

--- a/docs/opcodes/55/homestead.mdx
+++ b/docs/opcodes/55/homestead.mdx
@@ -4,4 +4,4 @@ The static cost is {gasPrices|sstore}. If the value is changed from zero to non-
 
 ## Gas refunds
 
-If the value is changed from non-zero to zero, adds {gasPrices|sstoreRefund} to the gas refunds. See [gas refunds](/about).
+If the value is changed from non-zero to zero, adds {gasPrices|sstoreRefund} to the gas refunds. See [gas refunds](/about#gasrefunds).

--- a/docs/opcodes/55/istanbul.mdx
+++ b/docs/opcodes/55/istanbul.mdx
@@ -1,22 +1,22 @@
 ## Gas
 
 ### Definitions:
+
 - **value**: value from the stack input.
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
+  static_gas = {gasPrices|sstore}
 
-    static_gas = {gasPrices|sstore}
-
-    if value == current_value
-        dynamic_gas = {gasPrices|sstoreNoopGasEIP2200}
-    else if current_value == original_value
-        if original_value == 0
-            dynamic_gas = {gasPrices|sstoreInitGasEIP2200}
-        else
-            dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
-    else
-        dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
+  if value == current_value
+  dynamic_gas = {gasPrices|sstoreNoopGasEIP2200}
+  else if current_value == original_value
+  if original_value == 0
+  dynamic_gas = {gasPrices|sstoreInitGasEIP2200}
+  else
+  dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
+  else
+  dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
 
 ## Gas refunds
 
@@ -36,4 +36,4 @@
                 else
                     gas_refunds += {gasPrices|sstoreCleanRefundEIP2200}
 
-See [gas refunds](/about).
+See [gas refunds](/about#gasrefunds).

--- a/docs/opcodes/55/petersburg.mdx
+++ b/docs/opcodes/55/petersburg.mdx
@@ -1,7 +1,7 @@
 ## Gas
 
-The static cost is {gasPrices|sstore}. If the value is changed from zero to non-zero, then the dynamic gas is {gasPrices|sstoreSet}. Otherwise the dynamic gas  is {gasPrices|sstoreReset}.
+The static cost is {gasPrices|sstore}. If the value is changed from zero to non-zero, then the dynamic gas is {gasPrices|sstoreSet}. Otherwise the dynamic gas is {gasPrices|sstoreReset}.
 
 ## Gas refunds
 
-If the value is changed from non-zero to zero, adds {gasPrices|sstoreRefund} to the gas refunds. See [gas refunds](/about).
+If the value is changed from non-zero to zero, adds {gasPrices|sstoreRefund} to the gas refunds. See [gas refunds](/about#gasrefunds).

--- a/docs/opcodes/56.mdx
+++ b/docs/opcodes/56.mdx
@@ -3,17 +3,17 @@ fork: Frontier
 group: Stack Memory Storage and Flow Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
-The program counter (PC) is a byte offset in the deployed [code](/about). It indicates which instruction will be executed next. When an [ADD](/#01) is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The [PUSH](/#60) instructions are bigger than one byte, and so will increment the counter accordingly.
+The program counter (PC) is a byte offset in the deployed [code](/about#code). It indicates which instruction will be executed next. When an [ADD](/#01) is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The [PUSH](/#60) instructions are bigger than one byte, and so will increment the counter accordingly.
 
-The **JUMP** instruction alters the program counter, thus breaking the linear path of the execution to another point in the deployed [code](/about). It is used to implement functionalities like functions.
+The **JUMP** instruction alters the program counter, thus breaking the linear path of the execution to another point in the deployed [code](/about#code). It is used to implement functionalities like functions.
 
 ## Stack input
 
-0. `counter`: byte offset in the deployed [code](/about) where execution will continue from. Must be a [JUMPDEST](/#5B) instruction.
+0. `counter`: byte offset in the deployed [code](/about#code) where execution will continue from. Must be a [JUMPDEST](/#5B) instruction.
 
 ## Example
 
@@ -22,6 +22,7 @@ The **JUMP** instruction alters the program counter, thus breaking the linear pa
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - `Counter` offset is not a [JUMPDEST](/#5B). The error is generated even if the JUMP would not have been done.

--- a/docs/opcodes/57.mdx
+++ b/docs/opcodes/57.mdx
@@ -3,17 +3,17 @@ fork: Frontier
 group: Stack Memory Storage and Flow Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
-The program counter (PC) is a byte offset in the deployed [code](/about). It indicates which instruction will be executed next. When an [ADD](/#01) is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The [PUSH](/#60) instructions are bigger than one byte, and so will increment the counter accordingly.
+The program counter (PC) is a byte offset in the deployed [code](/about#code). It indicates which instruction will be executed next. When an [ADD](/#01) is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The [PUSH](/#60) instructions are bigger than one byte, and so will increment the counter accordingly.
 
-The **JUMPI** instruction may alter the program counter, thus breaking the linear path of the execution to another point in the deployed [code](/about). It is used to implement functionalities like loops and conditions.
+The **JUMPI** instruction may alter the program counter, thus breaking the linear path of the execution to another point in the deployed [code](/about#code). It is used to implement functionalities like loops and conditions.
 
 ## Stack input
 
-0. `counter`: byte offset in the deployed [code](/about) where execution will continue from. Must be a [JUMPDEST](/#5B) instruction.
+0. `counter`: byte offset in the deployed [code](/about#code) where execution will continue from. Must be a [JUMPDEST](/#5B) instruction.
 1. `b`: the program counter will be altered with the new value only if this value is different from 0. Otherwise, the program counter is simply incremented and the next instruction will be executed.
 
 ## Example
@@ -23,6 +23,7 @@ The **JUMPI** instruction may alter the program counter, thus breaking the linea
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - `Counter` offset is not a [JUMPDEST](/#5B). The error is generated only if the JUMP would have been done.

--- a/docs/opcodes/58.mdx
+++ b/docs/opcodes/58.mdx
@@ -3,11 +3,11 @@ fork: Frontier
 group: Stack Memory Storage and Flow Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
-The program counter (PC) is a byte offset in the deployed [code](/about). It indicates which instruction will be executed next. When an [ADD](/#01) is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The [PUSH](/#60) instructions are bigger than one byte, and so will increment the counter accordingly.
+The program counter (PC) is a byte offset in the deployed [code](/about#code). It indicates which instruction will be executed next. When an [ADD](/#01) is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The [PUSH](/#60) instructions are bigger than one byte, and so will increment the counter accordingly.
 
 ## Stack output
 
@@ -20,5 +20,6 @@ The program counter (PC) is a byte offset in the deployed [code](/about). It ind
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Stack overflow.

--- a/docs/opcodes/59.mdx
+++ b/docs/opcodes/59.mdx
@@ -3,15 +3,15 @@ fork: Frontier
 group: Stack Memory Storage and Flow Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
-The [memory](/about) is always fully accessible. What this instruction tracks is the highest offset that was accessed in the current execution. A first write or read to a bigger offset will trigger a [memory expansion](/about), which will cost gas. The size is always a multiple of a word (32 bytes).
+The [memory](/about#memory) is always fully accessible. What this instruction tracks is the highest offset that was accessed in the current execution. A first write or read to a bigger offset will trigger a [memory expansion](/about#memoryexpansion), which will cost gas. The size is always a multiple of a word (32 bytes).
 
 ## Stack output
 
-0. `size`: current [memory](/about) size in bytes (higher offset accessed until now + 1).
+0. `size`: current [memory](/about#memory) size in bytes (higher offset accessed until now + 1).
 
 ## Example
 
@@ -20,5 +20,6 @@ The [memory](/about) is always fully accessible. What this instruction tracks is
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Stack overflow.

--- a/docs/opcodes/A0.mdx
+++ b/docs/opcodes/A0.mdx
@@ -3,7 +3,7 @@ fork: Frontier
 group: Logging Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
@@ -11,12 +11,13 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 
 ## Stack input
 
-0. `offset`: byte offset in the [memory](/about) in bytes.
+0. `offset`: byte offset in the [memory](/about#memory) in bytes.
 1. `size`: byte size to copy.
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).

--- a/docs/opcodes/A0/homestead.mdx
+++ b/docs/opcodes/A0/homestead.mdx
@@ -4,4 +4,4 @@
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 
 For LOG0, `topic_count` is 0.
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/A1.mdx
+++ b/docs/opcodes/A1.mdx
@@ -3,7 +3,7 @@ fork: Frontier
 group: Logging Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
@@ -11,13 +11,14 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 
 ## Stack input
 
-0. `offset`: byte offset in the [memory](/about) in bytes.
+0. `offset`: byte offset in the [memory](/about#memory) in bytes.
 1. `size`: byte size to copy.
 2. `topic1`: 32-byte value.
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).

--- a/docs/opcodes/A1/homestead.mdx
+++ b/docs/opcodes/A1/homestead.mdx
@@ -4,4 +4,4 @@
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 
 For LOG1, `topic_count` is 1.
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/A2.mdx
+++ b/docs/opcodes/A2.mdx
@@ -3,7 +3,7 @@ fork: Frontier
 group: Logging Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
@@ -11,7 +11,7 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 
 ## Stack input
 
-0. `offset`: byte offset in the [memory](/about) in bytes.
+0. `offset`: byte offset in the [memory](/about#memory) in bytes.
 1. `size`: byte size to copy.
 2. `topic1`: 32-byte value.
 3. `topic2`: 32-byte value.
@@ -19,6 +19,7 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).

--- a/docs/opcodes/A2/homestead.mdx
+++ b/docs/opcodes/A2/homestead.mdx
@@ -4,4 +4,4 @@
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 
 For LOG2, `topic_count` is 2.
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/A3.mdx
+++ b/docs/opcodes/A3.mdx
@@ -3,7 +3,7 @@ fork: Frontier
 group: Logging Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
@@ -11,7 +11,7 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 
 ## Stack input
 
-0. `offset`: byte offset in the [memory](/about) in bytes.
+0. `offset`: byte offset in the [memory](/about#memory) in bytes.
 1. `size`: byte size to copy.
 2. `topic1`: 32-byte value.
 3. `topic2`: 32-byte value.
@@ -20,6 +20,7 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).

--- a/docs/opcodes/A3/homestead.mdx
+++ b/docs/opcodes/A3/homestead.mdx
@@ -4,4 +4,4 @@
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 
 For LOG3, `topic_count` is 3.
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/A4.mdx
+++ b/docs/opcodes/A4.mdx
@@ -3,7 +3,7 @@ fork: Frontier
 group: Logging Operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
@@ -11,7 +11,7 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 
 ## Stack input
 
-0. `offset`: byte offset in the [memory](/about) in bytes.
+0. `offset`: byte offset in the [memory](/about#memory) in bytes.
 1. `size`: byte size to copy.
 2. `topic1`: 32-byte value.
 3. `topic2`: 32-byte value.
@@ -21,6 +21,7 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).

--- a/docs/opcodes/A4/homestead.mdx
+++ b/docs/opcodes/A4/homestead.mdx
@@ -4,4 +4,4 @@
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 
 For LOG4, `topic_count` is 4.
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/F0.mdx
+++ b/docs/opcodes/F0.mdx
@@ -3,21 +3,22 @@ fork: Frontier
 group: System operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
-Creates a new contract. Enters a new sub [context](/about) of the calculated destination address and executes the provided initialisation code, then resumes the current context.
+Creates a new contract. Enters a new sub [context](/about#executionenv) of the calculated destination address and executes the provided initialisation code, then resumes the current context.
 
-Should deployment succeed, the new account's [code](/about) is set to the [return data](/about) resulting from executing the initialisation code.
+Should deployment succeed, the new account's [code](/about#code) is set to the [return data](/about#returndata) resulting from executing the initialisation code.
 
 The destination address is calculated as the rightmost 20 bytes (160 bits) of the Keccak-256 hash of the rlp encoding of the sender address followed by its nonce. That is:
 
     address = keccak256(rlp([sender_address,sender_nonce]))[12:]
 
 Deployment can fail due to:
+
 - Insufficient value to send.
-- Sub [context](/about) [reverted](/#FD).
+- Sub [context](/about#executionenv) [reverted](/#FD).
 - Insufficient gas to execute the initialisation code.
 - Call depth limit reached.
 
@@ -26,7 +27,7 @@ Note that these failures only affect the return value and do not cause the calli
 ## Stack input
 
 0. `value`: value in [wei](https://www.investopedia.com/terms/w/wei.asp) to send to the new account.
-1. `offset`: byte offset in the [memory](/about) in bytes, the initialisation code for the new account.
+1. `offset`: byte offset in the [memory](/about#memory) in bytes, the initialisation code for the new account.
 2. `size`: byte size to copy (size of the initialisation code).
 
 ## Stack output
@@ -40,6 +41,7 @@ Note that these failures only affect the return value and do not cause the calli
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).

--- a/docs/opcodes/F0/berlin.mdx
+++ b/docs/opcodes/F0/berlin.mdx
@@ -7,6 +7,6 @@
 
 The `deployment_code_execution_cost` is the cost of whatever opcode is run to deploy the new contract.
 On top of that, there is an additional cost for storing the code of the new contract, shown as `code_deposit_cost`.
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
 
-The new contract address is added in the warm addresses. See section [access sets](/about).
+The new contract address is added in the warm addresses. See section [access sets](/about#accesssets).

--- a/docs/opcodes/F0/homestead.mdx
+++ b/docs/opcodes/F0/homestead.mdx
@@ -7,4 +7,4 @@
 
 The `deployment_code_execution_cost` is the cost of whatever opcode is run to deploy the new contract.
 On top of that, there is an additional cost for storing the code of the new contract, shown as `code_deposit_cost`.
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/F1.mdx
+++ b/docs/opcodes/F1.mdx
@@ -3,29 +3,29 @@ fork: Frontier
 group: System operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
-Creates a new sub [context](/about) and execute the [code](/about) of the given account, then resumes the current one. Note that an account with no code will return success as true.
+Creates a new sub [context](/about#executionenv) and execute the [code](/about#code) of the given account, then resumes the current one. Note that an account with no code will return success as true.
 
-If the size of the [return data](/about) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork).
+If the size of the [return data](/about#returndata) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork).
 
 From the Tangerine Whistle fork, `gas` is capped at all but one 64th (`remaining_gas / 64`) of the remaining gas of the current context. If a call tries to send more, the `gas` is changed to match the maximum allowed.
 
 ## Stack input
 
-0. `gas`: amount of gas to send to the sub [context](/about) to execute. The gas that is not used by the sub context is returned to this one.
-1. `address`: the account which [context](/about) to execute.
+0. `gas`: amount of gas to send to the sub [context](/about#executionenv) to execute. The gas that is not used by the sub context is returned to this one.
+1. `address`: the account which [context](/about#executionenv) to execute.
 2. `value`: [value](/#34) in [wei](https://www.investopedia.com/terms/w/wei.asp) to send to the account.
-3. `argsOffset`: byte offset in the [memory](/about) in bytes, the [calldata](/about) of the sub [context](/about).
-4. `argsSize`: byte size to copy (size of the [calldata](/about)).
-5. `retOffset`: byte offset in the [memory](/about) in bytes, where to store the [return data](/about) of the sub [context](/about).
-6. `retSize`: byte size to copy (size of the [return data](/about)).
+3. `argsOffset`: byte offset in the [memory](/about#memory) in bytes, the [calldata](/about#calldata) of the sub [context](/about#executionenv).
+4. `argsSize`: byte size to copy (size of the [calldata](/about#calldata)).
+5. `retOffset`: byte offset in the [memory](/about#memory) in bytes, where to store the [return data](/about#returndata) of the sub [context](/about#executionenv).
+6. `retSize`: byte size to copy (size of the [return data](/about#returndata)).
 
 ## Stack output
 
-0. `success`: return 0 if the sub [context](/about) [reverted](/#FD), 1 otherwise.
+0. `success`: return 0 if the sub [context](/about#executionenv) [reverted](/#FD), 1 otherwise.
 
 ## Examples
 
@@ -34,6 +34,7 @@ From the Tangerine Whistle fork, `gas` is capped at all but one 64th (`remaining
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - The current execution context is from a [STATICCALL](/#FA) and the [value](/#34) (stack index 2) is not 0 (since Byzantium fork).

--- a/docs/opcodes/F1/berlin.mdx
+++ b/docs/opcodes/F1/berlin.mdx
@@ -3,10 +3,11 @@
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost + value_to_empty_account_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
 
 The different costs are:
- - `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
- - If `address` is warm, then `address_access_cost` is {gasPrices|warmstorageread}, otherwise it is {gasPrices|coldaccountaccess}. See section [access sets](/about).
- - If `value` is not 0, then `positive_value_cost` is {gasPrices|callValueTransfer}. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called. {gasPrices|callStipend} is thus removed from the cost, and also added to the `gas` input.
- - If `value` is not 0 and the `address` given points to an empty account, then `value_to_empty_account_cost` is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code.
+
+- `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
+- If `address` is warm, then `address_access_cost` is {gasPrices|warmstorageread}, otherwise it is {gasPrices|coldaccountaccess}. See section [access sets](/about#accesssets).
+- If `value` is not 0, then `positive_value_cost` is {gasPrices|callValueTransfer}. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called. {gasPrices|callStipend} is thus removed from the cost, and also added to the `gas` input.
+- If `value` is not 0 and the `address` given points to an empty account, then `value_to_empty_account_cost` is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code.

--- a/docs/opcodes/F1/homestead.mdx
+++ b/docs/opcodes/F1/homestead.mdx
@@ -3,9 +3,10 @@
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + positive_value_cost + empty_account_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
 
 The different costs are:
- - `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
- - If `value` is not 0, then `positive_value_cost` is {gasPrices|callValueTransfer}. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called. {gasPrices|callStipend} is thus removed from the cost, and also added to the `gas` input.
- - If no account exists at the given `address`, then `empty_account_cost` is {gasPrices|callNewAccount}.
+
+- `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
+- If `value` is not 0, then `positive_value_cost` is {gasPrices|callValueTransfer}. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called. {gasPrices|callStipend} is thus removed from the cost, and also added to the `gas` input.
+- If no account exists at the given `address`, then `empty_account_cost` is {gasPrices|callNewAccount}.

--- a/docs/opcodes/F1/spuriousDragon.mdx
+++ b/docs/opcodes/F1/spuriousDragon.mdx
@@ -3,9 +3,10 @@
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + positive_value_cost + value_to_empty_account_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
 
 The different costs are:
- - `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
- - If `value` is not 0, then `positive_value_cost` is {gasPrices|callValueTransfer}. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called. {gasPrices|callStipend} is thus removed from the cost, and also added to the `gas` input.
- - If `value` is not 0 and the `address` given points to an empty account, then `value_to_empty_account_cost` is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code.
+
+- `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
+- If `value` is not 0, then `positive_value_cost` is {gasPrices|callValueTransfer}. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called. {gasPrices|callStipend} is thus removed from the cost, and also added to the `gas` input.
+- If `value` is not 0 and the `address` given points to an empty account, then `value_to_empty_account_cost` is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code.

--- a/docs/opcodes/F2.mdx
+++ b/docs/opcodes/F2.mdx
@@ -3,29 +3,29 @@ fork: Frontier
 group: System operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
-Creates a new sub [context](/about) as if calling itself, but with the [code](/about) of the given account. In particular the [storage](/about) remains the same. Note that an account with no code will return success as true.
+Creates a new sub [context](/about#executionenv) as if calling itself, but with the [code](/about#code) of the given account. In particular the [storage](/about#storage) remains the same. Note that an account with no code will return success as true.
 
-If the size of the [return data](/about) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork).
+If the size of the [return data](/about#returndata) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork).
 
 From the Tangerine Whistle fork, `gas` is capped at all but one 64th (`remaining_gas / 64`) of the remaining gas of the current context. If a call tries to send more, the `gas` is changed to match the maximum allowed.
 
 ## Stack input
 
-0. `gas`: amount of gas to send to the sub [context](/about) to execute. The gas that is not used by the sub context is returned to this one.
-1. `address`: the account which [code](/about) to execute.
+0. `gas`: amount of gas to send to the sub [context](/about#executionenv) to execute. The gas that is not used by the sub context is returned to this one.
+1. `address`: the account which [code](/about#code) to execute.
 2. `value`: [value](/#34) in [wei](https://www.investopedia.com/terms/w/wei.asp) to send to the account.
-3. `argsOffset`: byte offset in the [memory](/about) in bytes, the [calldata](/about) of the sub [context](/about).
-4. `argsSize`: byte size to copy (size of the [calldata](/about)).
-5. `retOffset`: byte offset in the [memory](/about) in bytes, where to store the [return data](/about) of the sub [context](/about).
-6. `retSize`: byte size to copy (size of the [return data](/about)).
+3. `argsOffset`: byte offset in the [memory](/about#memory) in bytes, the [calldata](/about#calldata) of the sub [context](/about#executionenv).
+4. `argsSize`: byte size to copy (size of the [calldata](/about#calldata)).
+5. `retOffset`: byte offset in the [memory](/about#memory) in bytes, where to store the [return data](/about#returndata) of the sub [context](/about#executionenv).
+6. `retSize`: byte size to copy (size of the [return data](/about#returndata)).
 
 ## Stack output
 
-0. `success`: return 0 if the sub [context](/about) [reverted](/#FD), 1 otherwise.
+0. `success`: return 0 if the sub [context](/about#executionenv) [reverted](/#FD), 1 otherwise.
 
 ## Examples
 
@@ -34,5 +34,6 @@ From the Tangerine Whistle fork, `gas` is capped at all but one 64th (`remaining
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/F2/berlin.mdx
+++ b/docs/opcodes/F2/berlin.mdx
@@ -3,9 +3,10 @@
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
 
 The different costs are:
- - `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
- - If `address` is warm, then `address_access_cost` is {gasPrices|warmstorageread}, otherwise it is {gasPrices|coldaccountaccess}. See section [access sets](/about).
- - If `value` is not 0, then `positive_value_cost` is {gasPrices|callValueTransfer}. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called. {gasPrices|callStipend} is thus removed from the cost, and also added to the `gas` input.
+
+- `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
+- If `address` is warm, then `address_access_cost` is {gasPrices|warmstorageread}, otherwise it is {gasPrices|coldaccountaccess}. See section [access sets](/about#accesssets).
+- If `value` is not 0, then `positive_value_cost` is {gasPrices|callValueTransfer}. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called. {gasPrices|callStipend} is thus removed from the cost, and also added to the `gas` input.

--- a/docs/opcodes/F2/homestead.mdx
+++ b/docs/opcodes/F2/homestead.mdx
@@ -3,8 +3,9 @@
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + positive_value_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
 
 The different costs are:
- - `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
- - If `value` is not 0, then `positive_value_cost` is {gasPrices|callValueTransfer}. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called. {gasPrices|callStipend} is thus removed from the cost, and also added to the `gas` input.
+
+- `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
+- If `value` is not 0, then `positive_value_cost` is {gasPrices|callValueTransfer}. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called. {gasPrices|callStipend} is thus removed from the cost, and also added to the `gas` input.

--- a/docs/opcodes/F3.mdx
+++ b/docs/opcodes/F3.mdx
@@ -3,36 +3,37 @@ fork: Frontier
 group: System operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
-Exits the current [context](/about) successfully.
+Exits the current [context](/about#executionenv) successfully.
 
 ## Stack input
 
-0. `offset`: byte offset in the [memory](/about) in bytes, to copy what will be the [return data](/about) of this [context](/about).
-1. `size`: byte size to copy (size of the [return data](/about)).
+0. `offset`: byte offset in the [memory](/about#memory) in bytes, to copy what will be the [return data](/about#returndata) of this [context](/about#executionenv).
+1. `size`: byte size to copy (size of the [return data](/about#returndata)).
 
 ## Example
 
-| `1` | Memory |
-|--:|------:|
+| `1` |   Memory |
+| --: | -------: |
 | `1` | `0xFF01` |
 
-| * | Input |
-|--:|-----:|
-| `1` | `0` |
-| `1` | `2` |
+|  \* | Input |
+| --: | ----: |
+| `1` |   `0` |
+| `1` |   `2` |
 
 | `1` | Calling context return data |
-|--:|---------------------------:|
-| `1` | `0xFF01` |
+| --: | --------------------------: |
+| `1` |                    `0xFF01` |
 
 [Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='wSet%20the%20statev32%200xFF01uuuuuz0yMSTOREyywExamplez2z0yRETURN'~000000zv1%20y%5Cnw%2F%2F%20vyPUSHu~~%01uvwyz~_).
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/F3/homestead.mdx
+++ b/docs/opcodes/F3/homestead.mdx
@@ -3,4 +3,4 @@
     static_gas = {gasPrices|return}
     dynamic_gas = memory_expansion_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/F4.mdx
+++ b/docs/opcodes/F4.mdx
@@ -3,28 +3,28 @@ fork: Byzantium
 group: System operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
-Creates a new sub [context](/about) as if calling itself, but with the [code](/about) of the given account. In particular the [storage](/about), the current [sender](/#33) and the current [value](/#34) remain the same. Note that an account with no code will return success as true.
+Creates a new sub [context](/about#executionenv) as if calling itself, but with the [code](/about#code) of the given account. In particular the [storage](/about#storage), the current [sender](/#33) and the current [value](/#34) remain the same. Note that an account with no code will return success as true.
 
-If the size of the [return data](/about) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork).
+If the size of the [return data](/about#returndata) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork).
 
 From the Tangerine Whistle fork, `gas` is capped at all but one 64th (`remaining_gas / 64`) of the remaining gas of the current context. If a call tries to send more, the `gas` is changed to match the maximum allowed.
 
 ## Stack input
 
-0. `gas`: amount of gas to send to the sub [context](/about) to execute. The gas that is not used by the sub context is returned to this one.
-1. `address`: the account which [code](/about) to execute.
-2. `argsOffset`: byte offset in the [memory](/about) in bytes, the [calldata](/about) of the sub [context](/about).
-3. `argsSize`: byte size to copy (size of the [calldata](/about)).
-4. `retOffset`: byte offset in the [memory](/about) in bytes, where to store the [return data](/about) of the sub [context](/about).
-5. `retSize`: byte size to copy (size of the [return data](/about)).
+0. `gas`: amount of gas to send to the sub [context](/about#executionenv) to execute. The gas that is not used by the sub context is returned to this one.
+1. `address`: the account which [code](/about#code) to execute.
+2. `argsOffset`: byte offset in the [memory](/about#memory) in bytes, the [calldata](/about#calldata) of the sub [context](/about#executionenv).
+3. `argsSize`: byte size to copy (size of the [calldata](/about#calldata)).
+4. `retOffset`: byte offset in the [memory](/about#memory) in bytes, where to store the [return data](/about#returndata) of the sub [context](/about#executionenv).
+5. `retSize`: byte size to copy (size of the [return data](/about#returndata)).
 
 ## Stack output
 
-0. `success`: return 0 if the sub [context](/about) [reverted](/#FD), 1 otherwise.
+0. `success`: return 0 if the sub [context](/about#executionenv) [reverted](/#FD), 1 otherwise.
 
 ## Examples
 
@@ -33,5 +33,6 @@ From the Tangerine Whistle fork, `gas` is capped at all but one 64th (`remaining
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/F4/berlin.mdx
+++ b/docs/opcodes/F4/berlin.mdx
@@ -3,8 +3,9 @@
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
 
 The different costs are:
- - `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
- - If `address` is warm, then `address_access_cost` is {gasPrices|warmstorageread}, otherwise it is {gasPrices|coldaccountaccess}. See section [access sets](/about).
+
+- `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
+- If `address` is warm, then `address_access_cost` is {gasPrices|warmstorageread}, otherwise it is {gasPrices|coldaccountaccess}. See section [access sets](/about#accesssets).

--- a/docs/opcodes/F4/homestead.mdx
+++ b/docs/opcodes/F4/homestead.mdx
@@ -3,7 +3,8 @@
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
 
 The different costs are:
- - `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
+
+- `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).

--- a/docs/opcodes/F5.mdx
+++ b/docs/opcodes/F5.mdx
@@ -3,13 +3,13 @@ fork: Constantinople
 group: System operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
 Equivalent to [CREATE](/#F0), except the salt allows the new contract to be deployed at a consistent, deterministic address.
 
-Should deployment succeed, the account's [code](/about) is set to the [return data](/about) resulting from executing the initialisation code.
+Should deployment succeed, the account's [code](/about#code) is set to the [return data](/about#returndata) resulting from executing the initialisation code.
 
 The destination address is calculated as follows:
 
@@ -17,9 +17,10 @@ The destination address is calculated as follows:
     address = keccak256(0xff + sender_address + salt + keccak256(initialisation_code))[12:]
 
 Deployment can fail due to:
+
 - A contract already exists at the destination address.
 - Insufficient value to transfer.
-- Sub [context](/about) [reverted](/#FD).
+- Sub [context](/about#executionenv) [reverted](/#FD).
 - Insufficient gas to execute the initialisation code.
 - Call depth limit reached.
 
@@ -28,7 +29,7 @@ Note that these failures only affect the return value and do not cause the calli
 ## Stack input
 
 0. `value`: value in [wei](https://www.investopedia.com/terms/w/wei.asp) to send to the new account.
-1. `offset`: byte offset in the [memory](/about) in bytes, the initialisation code of the new account.
+1. `offset`: byte offset in the [memory](/about#memory) in bytes, the initialisation code of the new account.
 2. `size`: byte size to copy (size of the initialisation code).
 3. `salt`: 32-byte value used to create the new account at a deterministic address.
 
@@ -43,6 +44,7 @@ Note that these failures only affect the return value and do not cause the calli
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.
 - The current execution context is from a [STATICCALL](/#FA).

--- a/docs/opcodes/F5/berlin.mdx
+++ b/docs/opcodes/F5/berlin.mdx
@@ -9,6 +9,6 @@
 The `deployment_code_execution_cost` is the cost of whatever opcode is run to deploy the new contract.
 On top of that, there is an additional cost for storing the code of the new contract, shown as `code_deposit_cost`.
 The difference with [CREATE](#F0) is an additional cost to hash the initialisation code before.
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
 
-The new contract address is added in the warm addresses. See section [access sets](/about).
+The new contract address is added in the warm addresses. See section [access sets](/about#accesssets).

--- a/docs/opcodes/F5/constantinople.mdx
+++ b/docs/opcodes/F5/constantinople.mdx
@@ -9,4 +9,4 @@
 The `deployment_code_execution_cost` is the cost of whatever opcode is run to deploy the new contract.
 On top of that, there is an additional cost for storing the code of the new contract, shown as `code_deposit_cost`.
 The difference with [CREATE](#F0) is an additional cost to hash the code before.
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/FA.mdx
+++ b/docs/opcodes/FA.mdx
@@ -3,33 +3,34 @@ fork: Homestead
 group: System operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
-Creates a new sub [context](/about) and execute the [code](/about) of the given account, then resumes the current one. Note that an account with no code will return success as true (1).
+Creates a new sub [context](/about#executionenv) and execute the [code](/about#code) of the given account, then resumes the current one. Note that an account with no code will return success as true (1).
 
-This instructions is equivalent to [CALL](/#F1), except that it does not allow any state modifying instructions or sending ETH in the sub [context](/about). The disallowed instructions are [CREATE](/#F0), [CREATE2](/#F5), [LOG0](/#A0), [LOG1](/#A1), [LOG2](/#A2), [LOG3](/#A3), [LOG4](/#A4), [SSTORE](/#55), [SELFDESTRUCT](/#FF) and [CALL](/#F1) if the [value](/#34) sent is not 0.
+This instructions is equivalent to [CALL](/#F1), except that it does not allow any state modifying instructions or sending ETH in the sub [context](/about#executionenv). The disallowed instructions are [CREATE](/#F0), [CREATE2](/#F5), [LOG0](/#A0), [LOG1](/#A1), [LOG2](/#A2), [LOG3](/#A3), [LOG4](/#A4), [SSTORE](/#55), [SELFDESTRUCT](/#FF) and [CALL](/#F1) if the [value](/#34) sent is not 0.
 
-If the size of the [return data](/about) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork).
+If the size of the [return data](/about#returndata) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork).
 
 From the Tangerine Whistle fork, `gas` is capped at all but one 64th (`remaining_gas / 64`) of the remaining gas of the current context. If a call tries to send more, the `gas` is changed to match the maximum allowed.
 
 ## Stack input
 
-0. `gas`: amount of gas to send to the sub [context](/about) to execute. The gas that is not used by the sub context is returned to this one.
-1. `address`: the account which [context](/about) to execute.
-2. `argsOffset`: byte offset in the [memory](/about) in bytes, the [calldata](/about) of the sub [context](/about).
-3. `argsSize`: byte size to copy (size of the [calldata](/about)).
-4. `retOffset`: byte offset in the [memory](/about) in bytes, where to store the [return data](/about) of the sub [context](/about).
-5. `retSize`: byte size to copy (size of the [return data](/about)).
+0. `gas`: amount of gas to send to the sub [context](/about#executionenv) to execute. The gas that is not used by the sub context is returned to this one.
+1. `address`: the account which [context](/about#executionenv) to execute.
+2. `argsOffset`: byte offset in the [memory](/about#memory) in bytes, the [calldata](/about#calldata) of the sub [context](/about#executionenv).
+3. `argsSize`: byte size to copy (size of the [calldata](/about#calldata)).
+4. `retOffset`: byte offset in the [memory](/about#memory) in bytes, where to store the [return data](/about#returndata) of the sub [context](/about#executionenv).
+5. `retSize`: byte size to copy (size of the [return data](/about#returndata)).
 
 ## Stack output
 
-0. `success`: return 0 if the sub [context](/about) [reverted](/#FD), 1 otherwise.
+0. `success`: return 0 if the sub [context](/about#executionenv) [reverted](/#FD), 1 otherwise.
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/FA/berlin.mdx
+++ b/docs/opcodes/FA/berlin.mdx
@@ -3,8 +3,9 @@
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
 
 The different costs are:
- - `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
- - If `address` is warm, then `address_access_cost` is {gasPrices|warmstorageread}, otherwise it is {gasPrices|coldaccountaccess}. See section [access sets](/about).
+
+- `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
+- If `address` is warm, then `address_access_cost` is {gasPrices|warmstorageread}, otherwise it is {gasPrices|coldaccountaccess}. See section [access sets](/about#accesssets).

--- a/docs/opcodes/FA/homestead.mdx
+++ b/docs/opcodes/FA/homestead.mdx
@@ -3,7 +3,8 @@
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).
 
 The different costs are:
- - `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).
+
+- `code_execution_cost` is the cost of the called code execution (limited by the `gas` parameter).

--- a/docs/opcodes/FD.mdx
+++ b/docs/opcodes/FD.mdx
@@ -3,39 +3,40 @@ fork: Byzantium
 group: System operations
 ---
 
-*Index 1 is top of the stack. See [PUSH](/#60).*
+_Index 1 is top of the stack. See [PUSH](/#60)._
 
 ## Notes
 
 Stop the current context execution, revert the state changes (see [STATICCALL](/#FA) for a list of state changing opcodes) and return the unused gas to the caller.
 It also reverts the gas refund to its value before the current context.
 If the execution is stopped with REVERT, the value 0 is put on the stack of the calling context, which continues to execute normally.
-The [return data](/about) of the calling context is set as the given chunk of memory of this context.
+The [return data](/about#returndata) of the calling context is set as the given chunk of memory of this context.
 
 ## Stack input
 
-0. `offset`: byte offset in the [memory](/about) in bytes. The return data of the calling context.
-1. `size`: byte size to copy (size of the [return data](/about)).
+0. `offset`: byte offset in the [memory](/about#memory) in bytes. The return data of the calling context.
+1. `size`: byte size to copy (size of the [return data](/about#returndata)).
 
 ## Example
 
-| `1` | Memory |
-|--:|------:|
+| `1` |   Memory |
+| --: | -------: |
 | `1` | `0xFF01` |
 
-| * | Input |
-|--:|-----:|
-| `1` | `0` |
-| `1` | `2` |
+|  \* | Input |
+| --: | ----: |
+| `1` |   `0` |
+| `1` |   `2` |
 
 | `1` | Calling context return data |
-|--:|---------------------------:|
-| `1` | `0xFF01` |
+| --: | --------------------------: |
+| `1` |                    `0xFF01` |
 
 [Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='wSet%20the%20statev32%200xFF01uuuuuz0yMSTOREyywExamplez2z0yREVERT'~000000zv1%20y%5Cnw%2F%2F%20vyPUSHu~~%01uvwyz~_).
 
 ## Error cases
 
 The state changes done by the current context are [reverted](#FD) in those cases:
+
 - Not enough gas.
 - Not enough values on the stack.

--- a/docs/opcodes/FD/homestead.mdx
+++ b/docs/opcodes/FD/homestead.mdx
@@ -3,4 +3,4 @@
     static_gas = {gasPrices|return}
     dynamic_gas = memory_expansion_cost
 
-The memory expansion cost explanation can be found [here](/about).
+The memory expansion cost explanation can be found [here](/about#memoryexpansion).

--- a/docs/opcodes/FF/berlin.mdx
+++ b/docs/opcodes/FF/berlin.mdx
@@ -1,7 +1,7 @@
 ## Gas
 
-The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an empty account, the dynamic gas is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code. Additionaly, if `address` is cold, there is an additional dynamic cost of {gasPrices|coldaccountaccess}. See section [access sets](/about). There is no additional cost otherwise.
+The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an empty account, the dynamic gas is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code. Additionaly, if `address` is cold, there is an additional dynamic cost of {gasPrices|coldaccountaccess}. See section [access sets](/about#accesssets). There is no additional cost otherwise.
 
 ## Gas refunds
 
-Adds {gasPrices|selfdestructRefund} to the gas refunds. See [gas refunds](/about).
+Adds {gasPrices|selfdestructRefund} to the gas refunds. See [gas refunds](/about#gasrefunds).

--- a/docs/opcodes/FF/homestead.mdx
+++ b/docs/opcodes/FF/homestead.mdx
@@ -1,3 +1,3 @@
 ## Gas refunds
 
-Adds {gasPrices|selfdestructRefund} to the gas refunds. See [gas refunds](/about).
+Adds {gasPrices|selfdestructRefund} to the gas refunds. See [gas refunds](/about#gasrefunds).

--- a/docs/opcodes/FF/london.mdx
+++ b/docs/opcodes/FF/london.mdx
@@ -1,3 +1,3 @@
 ## Gas
 
-The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an empty account, the dynamic gas is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code. Additionaly, if `address` is cold, there is an additional dynamic cost of {gasPrices|coldaccountaccess}. See section [access sets](/about). There is no additional cost otherwise.
+The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an empty account, the dynamic gas is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code. Additionaly, if `address` is cold, there is an additional dynamic cost of {gasPrices|coldaccountaccess}. See section [access sets](/about#accesssets). There is no additional cost otherwise.

--- a/docs/opcodes/FF/spuriousDragon.mdx
+++ b/docs/opcodes/FF/spuriousDragon.mdx
@@ -4,4 +4,4 @@ The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an 
 
 ## Gas refunds
 
-Adds {gasPrices|selfdestructRefund} to the gas refunds. See [gas refunds](/about).
+Adds {gasPrices|selfdestructRefund} to the gas refunds. See [gas refunds](/about#gasrefunds).

--- a/docs/opcodes/FF/tangerineWhistle.mdx
+++ b/docs/opcodes/FF/tangerineWhistle.mdx
@@ -4,4 +4,4 @@ The static gas is {gasPrices|selfdestruct}. If `address` is an unexisting accoun
 
 ## Gas refunds
 
-Adds {gasPrices|selfdestructRefund} to the gas refunds. See [gas refunds](/about).
+Adds {gasPrices|selfdestructRefund} to the gas refunds. See [gas refunds](/about#gasrefunds).


### PR DESCRIPTION
Inside this PR I have updated all the `/about` reference to the specific section inside the About page. 

For example 

```diff
-[calldata](/about)
+[calldata](/about#calldata)
```

## Important note

Don't ask me why, but my prettier/dunno what have sometimes auto-formatted some markdown section :(