### PR TITLE
Fix gas reference for SSTORE

### DIFF
--- a/docs/opcodes/55/berlin.mdx
+++ b/docs/opcodes/55/berlin.mdx
@@ -6,20 +6,21 @@
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
-  static_gas = {gasPrices|sstore}
 
-  if value == current_value
-  if key is warm
-  base_dynamic_gas = {gasPrices|warmstorageread}
-  else
-  base_dynamic_gas = {gasPrices|sstoreNoopGasEIP2200}
-  else if current_value == original_value
-  if original_value == 0
-  base_dynamic_gas = {gasPrices|sstoreInitGasEIP2200}
-  else
-  base_dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
-  else
-  base_dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
+    static_gas = {gasPrices|sstore}
+
+    if value == current_value
+        if key is warm
+            base_dynamic_gas = {gasPrices|warmstorageread}
+        else
+            base_dynamic_gas = {gasPrices|sstoreNoopGasEIP2200}
+    else if current_value == original_value
+        if original_value == 0
+            base_dynamic_gas = {gasPrices|sstoreInitGasEIP2200}
+        else
+            base_dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
+    else
+        base_dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
 
 On top of the cost above, {gasPrices|coldsload} is added to `base_dynamic_gas` if the slot is cold. See section [access sets](/about#accesssets).
 

--- a/docs/opcodes/55/constantinople.mdx
+++ b/docs/opcodes/55/constantinople.mdx
@@ -6,17 +6,18 @@
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
-  static_gas = {gasPrices|sstore}
 
-  if value == current_value
-  dynamic_gas = {gasPrices|netSstoreNoopGas}
-  else if current_value == original_value
-  if original_value == 0
-  dynamic_gas = {gasPrices|netSstoreInitGas}
-  else
-  dynamic_gas = {gasPrices|netSstoreCleanGas}
-  else
-  dynamic_gas = {gasPrices|netSstoreDirtyGas}
+    static_gas = {gasPrices|sstore}
+
+    if value == current_value
+        dynamic_gas = {gasPrices|netSstoreNoopGas}
+    else if current_value == original_value
+        if original_value == 0
+            dynamic_gas = {gasPrices|netSstoreInitGas}
+        else
+            dynamic_gas = {gasPrices|netSstoreCleanGas}
+    else
+        dynamic_gas = {gasPrices|netSstoreDirtyGas}
 
 ## Gas refunds
 

--- a/docs/opcodes/55/istanbul.mdx
+++ b/docs/opcodes/55/istanbul.mdx
@@ -6,17 +6,18 @@
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
-  static_gas = {gasPrices|sstore}
 
-  if value == current_value
-  dynamic_gas = {gasPrices|sstoreNoopGasEIP2200}
-  else if current_value == original_value
-  if original_value == 0
-  dynamic_gas = {gasPrices|sstoreInitGasEIP2200}
-  else
-  dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
-  else
-  dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
+    static_gas = {gasPrices|sstore}
+
+    if value == current_value
+        dynamic_gas = {gasPrices|sstoreNoopGasEIP2200}
+    else if current_value == original_value
+        if original_value == 0
+            dynamic_gas = {gasPrices|sstoreInitGasEIP2200}
+        else
+            dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
+    else
+        dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
 
 ## Gas refunds
 


### PR DESCRIPTION
## Description

After #176, the `SSTORE` reference just broke due to a lack of indentation.
This PR fixes that

## Screenshots

### Before
<img width="1051" alt="Captura de Pantalla 2022-09-29 a la(s) 12 16 51" src="https://user-images.githubusercontent.com/33379285/193098459-3935c9de-305d-4fdc-9a79-564ef21bd6e0.png">

### After
<img width="594" alt="Captura de Pantalla 2022-09-29 a la(s) 12 16 57" src="https://user-images.githubusercontent.com/33379285/193098491-eb4c9f7f-e1cd-4174-a7f6-24a5e5d9294b.png">
