### PR TITLE
fix: getCallValue default on `/playground` page

### DIFF
--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -119,17 +119,16 @@ const Editor = ({ readOnly = false }: Props) => {
 
   const getCallValue = useCallback(() => {
     const _callValue = BigInt(callValue)
-    let cv = 0n
-
-    if (unit === ValueUnit.Gwei) {
-      cv = _callValue * BigInt('1000000000')
-    } else if (unit === ValueUnit.Finney) {
-      cv = _callValue * BigInt('1000000000000000')
-    } else if (unit === ValueUnit.Ether) {
-      cv = _callValue * BigInt('1000000000000000000')
+    switch (unit) {
+      case ValueUnit.Gwei:
+        return _callValue * BigInt('1000000000')
+      case ValueUnit.Finney:
+        return _callValue * BigInt('1000000000000000')
+      case ValueUnit.Ether:
+        return _callValue * BigInt('1000000000000000000')
+      default:
+        return _callValue;
     }
-
-    return cv
   }, [callValue, unit])
 
   const deployByteCode = useCallback(

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -127,7 +127,7 @@ const Editor = ({ readOnly = false }: Props) => {
       case ValueUnit.Ether:
         return _callValue * BigInt('1000000000000000000')
       default:
-        return _callValue;
+        return _callValue
     }
   }, [callValue, unit])
 


### PR DESCRIPTION
There's a bug in the `/playground` page where you cannot set a `value` when the unit is `Wei`.

You can reproduce the issue like this:

- go to https://www.evm.codes/playground?callValue=8&unit=Wei&callData=&codeType=Bytecode&code=%2734380356FDFD5B00FDFD%27_&fork=merge
- make sure that the value of the `Value to send` input is a non-zero value; leave the unit as `Wei`
- hit `Run`
- click the `Step into` button
- the `CALLVALUE` op code will push the current value onto the stack
- but if you look at the `STACK`, you'll see that it has pushed `0` onto the stack, not your specified value.

Here's a sceenshot of the bug in action. The value is set to `10 Wei`, but after calling `CALLVALUE` to push the value onto the stack, the stack only contains the value `0`.

![image](https://user-images.githubusercontent.com/2570291/200140613-dd3c9069-f871-4edf-9c9b-bcb14d046b60.png)


This looks like a bug that snuck in as part of #180:

https://github.com/comitylabs/evm.codes/pull/180/files#diff-f94ee558d29599b90de5ea99b772edb79bbdea7da82ee6714f41ccfe3c5030b5R122

The original `getCallValue` code returned `callValue` as the default value, potentially multiplying by some factor if the `unit` was not `ValueUnit.Wei`.

#180 erroneously changed that logic to default to `0` when the unit is `Wei`.

This PR restores the default value to `callValue`.