### PR TITLE
Feat: Live bytecode mode in Editor

### DIFF
--- a/bytecode.js
+++ b/bytecode.js
@@ -1,0 +1,15 @@
+function hljsDefineBytecode(hljs) {
+  return {
+    name: 'Bytecode',
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.HASH_COMMENT_MODE,
+      hljs.COMMENT(
+        ';', // begin
+        '$', // end
+      ),
+    ],
+  }
+}
+
+module.exports = hljsDefineBytecode

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -285,26 +285,29 @@ const Editor = ({ readOnly = false }: Props) => {
     }
   }
 
+  const stripBytecode = (value: string) => {
+    return value
+      .replaceAll(/\/\/.*$/gm, '')
+      .replaceAll(/;.*$/gm, '')
+      .replaceAll(/#.*$/gm, '')
+      .replaceAll(/\s/gm, '')
+  }
+
   const handleCodeChange = (value: string) => {
     setCode(value)
     setCodeModified(true)
 
     try {
       if (codeType === CodeType.Bytecode) {
-        const concatCode = value
-          .replaceAll(/\/\/.*$/gm, '')
-          .replaceAll(/;.*$/gm, '')
-          .replaceAll(/#.*$/gm, '')
-          .replaceAll(/\s/gm, '')
-        console.log(`|${concatCode}|`)
+        const cleanBytecode = stripBytecode(value)
 
         if (timeOutId) {
           clearTimeout(timeOutId)
           setTimeOutId(undefined)
         }
-        setTimeOutId(setTimeout(() => validateBytecode(concatCode), 1000))
+        setTimeOutId(setTimeout(() => validateBytecode(cleanBytecode), 1000))
 
-        loadInstructions(concatCode)
+        loadInstructions(cleanBytecode)
         // startExecution(value, _callValue, _callData)
       }
     } catch (error) {
@@ -384,16 +387,17 @@ const Editor = ({ readOnly = false }: Props) => {
         loadInstructions(bytecode)
         startExecution(bytecode, _callValue, _callData)
       } else if (codeType === CodeType.Bytecode) {
-        if (code.length % 2 !== 0) {
+        const cleanBytecode = stripBytecode(code)
+        if (cleanBytecode.length % 2 !== 0) {
           log('There should be at least 2 characters per byte', 'error')
           return
         }
-        if (!isHex(code)) {
+        if (!isHex(cleanBytecode)) {
           log('Only hexadecimal characters are allowed', 'error')
           return
         }
-        loadInstructions(code)
-        startExecution(code, _callValue, _callData)
+        loadInstructions(cleanBytecode)
+        startExecution(cleanBytecode, _callValue, _callData)
       } else {
         setIsCompiling(true)
         log('Starting compilation...')

--- a/util/string.ts
+++ b/util/string.ts
@@ -1,6 +1,7 @@
 import hljs from 'highlight.js/lib/core'
 import hljsDefineSolidity from 'highlightjs-solidity'
 
+import hljsDefineBytecode from '../bytecode.js'
 import hljsDefineMnemonic from '../mnemonic.js'
 
 const reHex = /^[0-9a-fA-F]+$/
@@ -9,6 +10,7 @@ const reFullHex = /^(0x|0X)([0-9a-fA-F][0-9a-fA-F])+$/
 // Add Solidity to Highlight
 hljsDefineSolidity(hljs)
 hljs.registerLanguage('mnemonic', hljsDefineMnemonic)
+hljs.registerLanguage('bytecode', hljsDefineBytecode)
 
 /**
  * Checks whether text is empty.


### PR DESCRIPTION
Proposing a live-updating editor in Bytecode mode - it shows the opcodes on the right when writing bytecode.
Should help much when analyzing/writing minimal contracts directly in Bytecode.

Features added:
- Live-update of the opcodes when editing the bytecode
- Ability to put spaces and newlines in bytecode without errors in compilations
- Ability to put comments in bytecode (three styles supported: `// comment`, `# comment`, `; comment`)
- Added `bytecode` language to HLJS with comments highlighting
- Delayed bytecode error validation for hex and even-byte length (for better typing UX)

Maybe something else can be added if interactive mode is worth going forward with, like:
- A switch "Interactive mode: ON/OFF"
- Show decoded opcodes on bytecode page loads
- Interchange between Bytecode/Mnemonics with the same instructions (saw in code, but don't know if it works)
- Add interactive mode for Mnemonics (Not sure about YUL/Solidity - it takes much longer to compile to be interactive)