### PR TITLE
Add space between words 'our' and 'reference' in About

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -257,8 +257,7 @@ const AboutPage = () => {
               <b>Opcode Fixed Execution Cost</b> : Each opcode has a fixed cost
               to be paid upon execution, measured in gas. This cost is the same
               for all executions, though this is subject to change in new
-              hardforks. See our
-              {' '}
+              hardforks. See our{' '}
               <a
                 href="https://www.evm.codes/"
                 target="_blank"
@@ -276,7 +275,7 @@ const AboutPage = () => {
               more work than others, depending on their parameters. Because of
               this, on top of fixed costs, some instructions have dynamic costs.
               These dynamic costs are dependant on several factors (which vary
-              from hardfork to hardfork). See our
+              from hardfork to hardfork). See our{' '}
               <a
                 href="https://www.evm.codes/"
                 target="_blank"

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -258,6 +258,7 @@ const AboutPage = () => {
               to be paid upon execution, measured in gas. This cost is the same
               for all executions, though this is subject to change in new
               hardforks. See our
+              {' '}
               <a
                 href="https://www.evm.codes/"
                 target="_blank"


### PR DESCRIPTION
Thanks for a very useful website. Just fixing this:

<img width="546" alt="Screenshot 2023-02-07 at 14 32 23" src="https://user-images.githubusercontent.com/5699893/217258713-57e9a014-8d78-48de-a04f-554d0f9666cc.png">