### PR TITLE
fix: whitespace

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -257,7 +257,7 @@ const AboutPage = () => {
               <b>Opcode Fixed Execution Cost</b> : Each opcode has a fixed cost
               to be paid upon execution, measured in gas. This cost is the same
               for all executions, though this is subject to change in new
-              hardforks. See our
+              hardforks. See our{' '}
               <a
                 href="https://www.evm.codes/"
                 target="_blank"


### PR DESCRIPTION
<img width="151" alt="Screenshot 2023-02-07 at 7 49 58 AM" src="https://user-images.githubusercontent.com/71567643/217294190-4021746e-6562-4758-9aac-3d0b0f2e5dfd.png">

Fixes a minor whitespace issue on the `About the EVM` page under `Gas Costs`

<img width="886" alt="Screenshot 2023-02-07 at 7 50 05 AM" src="https://user-images.githubusercontent.com/71567643/217294194-2912c986-14d0-431f-bde7-f90fa5b815f6.png">
