### PR TITLE
Fix: gas calculation modexp precompile

### DIFF
--- a/util/gas.ts
+++ b/util/gas.ts
@@ -578,12 +578,14 @@ export const calculatePrecompiledDynamicFee = (
       }
 
       if (common.gteHardfork('berlin')) {
-        result.imul(multComplexityEIP2565(maxLen)).divn(Gquaddivisor)
+        result.imul(multComplexityEIP2565(maxLen))
+	 result = result.divn(Gquaddivisor)
         if (result.ltn(200)) {
           result = new BN(200)
         }
       } else {
-        result.imul(multComplexity(maxLen)).divn(Gquaddivisor)
+        result.imul(multComplexity(maxLen))
+	 result = result.divn(Gquaddivisor)
       }
       break
     }

--- a/util/gas.ts
+++ b/util/gas.ts
@@ -579,13 +579,13 @@ export const calculatePrecompiledDynamicFee = (
 
       if (common.gteHardfork('berlin')) {
         result.imul(multComplexityEIP2565(maxLen))
-	 result = result.divn(Gquaddivisor)
+	result = result.divn(Gquaddivisor)
         if (result.ltn(200)) {
           result = new BN(200)
         }
       } else {
         result.imul(multComplexity(maxLen))
-	 result = result.divn(Gquaddivisor)
+	result = result.divn(Gquaddivisor)
       }
       break
     }


### PR DESCRIPTION
Here's a small bugfix for gas calcuation modexp precompile. Resolves https://github.com/comitylabs/evm.codes/issues/209